### PR TITLE
Polycon has been cancelled

### DIFF
--- a/conferences/2019/general.json
+++ b/conferences/2019/general.json
@@ -157,15 +157,6 @@
     "twitter": "@developer_week"
   },
   {
-    "name": "Polycon Summit Barcelona",
-    "url": "http://polycon.io",
-    "startDate": "2019-07-19",
-    "endDate": "2019-07-21",
-    "city": "Barcelona",
-    "country": "Spain",
-    "twitter": "@polycon_io"
-  },
-  {
     "name": "Codemotion Amsterdam",
     "url": "https://about.codemotion.com/",
     "startDate": "2019-04-02",


### PR DESCRIPTION
Message from: https://polycon.io/
Dear community.
Due to some important logistics and financial problems, the Polycon Barcelona organization decided to cancel the conference for next year. We spent a lot of time, energy and enthusiasm designing the conference, looking for great speakers and a great location, but we didn't find a proper way to make it happen.
We will return the money for all the tickets sold so far in the next days. We truly appreciate your interest in the event and we hope seeing you in any of the great upcoming events in Barcelona.
If you have any question or issue feel free to contact us and we will be delighted to help.

Att.
The Polycon Barcelona Organization