### PR TITLE
Removing incorrect CFP date

### DIFF
--- a/conferences/2018/javascript.json
+++ b/conferences/2018/javascript.json
@@ -152,7 +152,6 @@
     "url": "https://ngvikings.org",
     "startDate": "2018-03-01",
     "endDate": "2018-03-02",
-    "cfpEndDate": "2018-12-10",
     "city": "Helsinki",
     "country": "Finland",
     "twitter": "@ngVikingsConf"


### PR DESCRIPTION
This date is impossible as the conference is already passed. It seems that the date is right for the 2019 conference.

Removing this just removes confusion from the upcoming cfps list.