### PR TITLE
Updating PyCon Italia with full name.

### DIFF
--- a/conferences/2019/python.json
+++ b/conferences/2019/python.json
@@ -41,7 +41,7 @@
     "twitter": "@djangocon"
   },
   {
-    "name": "PyCon",
+    "name": "PyCon Italia",
     "url": "http://pycon.it/en",
     "startDate": "2019-05-02",
     "endDate": "2019-05-05",


### PR DESCRIPTION
This PyCon is the Italian edition, so it might help people to know in the name.