### PR TITLE
Fixed dates for JSNation and SmashingConf NY

### DIFF
--- a/conferences/2019/javascript.json
+++ b/conferences/2019/javascript.json
@@ -515,8 +515,8 @@
   {
     "name": "JSNation",
     "url": "http://amsterdamjs.com",
-    "startDate": "2019-05-31",
-    "endDate": "2019-06-01",
+    "startDate": "2019-06-06",
+    "endDate": "2019-06-07",
     "city": "Amsterdam",
     "country": "Netherlands",
     "twitter": "@amsterdamjs",
@@ -740,7 +740,7 @@
   {
     "name": "Smashing Conference",
     "url": "https://smashingconf.com/ny-2019/",
-    "startDate": "2019-09-15",
+    "startDate": "2019-10-15",
     "endDate": "2019-10-16",
     "city": "New York",
     "country": "U.S.A.",


### PR DESCRIPTION
Updated JSNation and Smashing Conf New York to the correct dates as listed on https://amsterdamjs.com/ and https://smashingconf.com/ny-2019/.