### PR TITLE
TF Blockchain conference in general category

### DIFF
--- a/conferences/2019/general.json
+++ b/conferences/2019/general.json
@@ -308,6 +308,15 @@
     "twitter": "@devconfza"
   },
   {
+    "name": "TF Blockchain",
+    "url": "https://www.tfblock.io/",
+    "startDate": "2019-03-28",
+    "endDate": "2019-03-28",
+    "city": "Seattle",
+    "country": "U.S.A.",
+    "twitter": "@tfblockchain"
+  },
+  {
     "name": "‹Programming›",
     "url": "https://2019.programming-conference.org",
     "startDate": "2019-04-01",


### PR DESCRIPTION
Replacement for https://github.com/tech-conferences/conference-data/pull/646