### PR TITLE
Remove THAT Conference from UX

### DIFF
--- a/conferences/2019/ux.json
+++ b/conferences/2019/ux.json
@@ -171,15 +171,6 @@
     "twitter": "@euroia"
   },
   {
-    "name": "That Conference",
-    "startDate": "2019-08-05",
-    "endDate": "2019-08-08",
-    "city": "Wisconsin Dells, WI",
-    "country": "U.S.A.",
-    "url": "https://www.thatconference.com",
-    "twitter": "@ThatConference"
-  },
-  {
     "name": "UX & Digital Design Week",
     "startDate": "2019-08-12",
     "endDate": "2019-08-16",


### PR DESCRIPTION
It's already listed under [general](https://github.com/tech-conferences/conference-data/blob/master/conferences/2019/general.json#L1263:L1271)