### PR TITLE
Fixing state abbreviation for Burlington

### DIFF
--- a/conferences/2019/ux.json
+++ b/conferences/2019/ux.json
@@ -420,7 +420,7 @@
     "name": "UX Burlington",
     "startDate": "2019-05-03",
     "endDate": "2019-05-03",
-    "city": "Burlington, VM",
+    "city": "Burlington, VT",
     "country": "U.S.A.",
     "url": "https://www.uxburlington.com",
     "twitter": "@uxburlington"


### PR DESCRIPTION
Vermont is `VT` not `VM` 😄 