### PR TITLE
Revert "Add Haystack conference"

### DIFF
--- a/conferences/2019/general.json
+++ b/conferences/2019/general.json
@@ -1397,16 +1397,6 @@
     "cfpEndDate": "2019-06-17"
   },
   {
-    "name": "Haystack",
-    "url": "https://haystackconf.com",
-    "startDate": "2019-07-28",
-    "endDate": "2019-07-28",
-    "city": "Berlin",
-    "country": "Germany",
-    "cfpUrl": "https://haystackconf.com",
-    "cfpEndDate": "2019-07-31"
-  },
-  {
     "name": "Balisage",
     "url": "https://www.balisage.net",
     "startDate": "2019-07-29",


### PR DESCRIPTION
Reverts tech-conferences/conference-data#1263

#1263 adds this conference to the General category with the wrong event dates. The conference is already added to the relevant Data category with #1256