### PR TITLE
Add RustFest Barcelona 2019

### DIFF
--- a/conferences/2019/rust.json
+++ b/conferences/2019/rust.json
@@ -47,5 +47,14 @@
     "city": "Portland, OR",
     "country": "U.S.A.",
     "twitter": "@rustconf"
+  },
+  {
+    "name": "RustFest Barcelona",
+    "url": "https://barcelona.rustfest.eu/",
+    "startDate": "2019-11-09",
+    "endDate": "2019-11-12",
+    "city": "Barcelona",
+    "country": "Spain",
+    "twitter": "@rustfest"
   }
 ]


### PR DESCRIPTION
Add the next RustFest which is happening in November of 2019 in
Barcelona, Spain.

Thanks for considering it.