### PR TITLE
Remove "PHP Central Europe" conf

### DIFF
--- a/conferences/2019/php.json
+++ b/conferences/2019/php.json
@@ -308,15 +308,6 @@
     "cfpEndDate": "2019-08-02"
   },
   {
-    "name": "php Central Europe",
-    "url": "https://2019.phpce.eu",
-    "startDate": "2019-10-04",
-    "endDate": "2019-10-06",
-    "city": "Dresden",
-    "country": "Germany",
-    "twitter": "@phpce_eu"
-  },
-  {
     "name": "Symfony Day",
     "url": "https://2019.symfonyday.it",
     "startDate": "2019-10-17",


### PR DESCRIPTION
Conference was cancelled, https://2019.phpce.eu/de/