### PR TITLE
Fix twitter account for Node+JS Interactive

### DIFF
--- a/conferences/2019/javascript.json
+++ b/conferences/2019/javascript.json
@@ -1842,6 +1842,6 @@
     "endDate": "2019-12-12",
     "city": "Montréal",
     "country": "Canada",
-    "twitter": "@Linux_Fdtn_JP"
+    "twitter": "@linuxfoundation"
   }
 ]


### PR DESCRIPTION
https://twitter.com/Linux_Fdtn_JP is an account of Linux Foundation Japan. [The conference's website](https://events.linuxfoundation.org/events/nodejs-interactive-2019/register/) links to https://twitter.com/linuxfoundation.