### PR TITLE
Update the duplicates test to make it less strict

### DIFF
--- a/scripts/tests/utils.js
+++ b/scripts/tests/utils.js
@@ -13,6 +13,11 @@ export function getDuplicates(conferences) {
   return duplicates;
 }
 
+/**
+ * Creates a unique ID for a conference from its url, city, year and month
+ * @param conf
+ * @returns {string}
+ */
 function getUUID(conf) {
-  return `${conf.url.replace(/https?:\/\//, '')}-${conf.city}`;
+  return `${conf.url.replace(/https?:\/\//, '')}-${conf.city}-${conf.startDate.slice(0, 7)}`;
 }


### PR DESCRIPTION
Now conference ID also includes year and month.
Allows having conferences that happens more than once a year in the same city (e.g. #1511)