### PR TITLE
Remove Nodevember 2019

### DIFF
--- a/conferences/2019/javascript.json
+++ b/conferences/2019/javascript.json
@@ -1863,15 +1863,6 @@
     "cfpEndDate": "2019-06-05"
   },
   {
-    "name": "Nodevember",
-    "url": "http://nodevember.org",
-    "startDate": "2019-11-27",
-    "endDate": "2019-11-28",
-    "city": "Nashville",
-    "country": "U.S.A.",
-    "twitter": "@nodevember"
-  },
-  {
     "name": "jsconf.jp",
     "url": "https://www.jsconf.jp",
     "startDate": "2019-11-30",


### PR DESCRIPTION
I added this through the bot interface by mistake. It doesn't seem to be happening. When I tried to find tickets through their website, it linked to tickets for the 2017 conference. Sorry!