### PR TITLE
Fix month for Agent Conf 2020

### DIFF
--- a/conferences/2020/javascript.json
+++ b/conferences/2020/javascript.json
@@ -11,6 +11,15 @@
     "cfpEndDate": "2019-09-15"
   },
   {
+    "name": "Agent Conf",
+    "url": "https://www.agent.sh",
+    "startDate": "2020-01-23",
+    "endDate": "2020-01-26",
+    "city": "Dornbirn & Lech",
+    "country": "Austria",
+    "twitter": "@AgentConf"
+  },
+  {
     "name": "Covalence",
     "url": "http://www.covalenceconf.com",
     "startDate": "2020-01-24",
@@ -87,15 +96,6 @@
     "city": "Amsterdam",
     "country": "Netherlands",
     "twitter": "@vuejsamsterdam"
-  },
-  {
-    "name": "Agent Conf",
-    "url": "https://www.agent.sh",
-    "startDate": "2020-02-23",
-    "endDate": "2020-02-26",
-    "city": "Dornbirn & Lech",
-    "country": "Austria",
-    "twitter": "@AgentConf"
   },
   {
     "name": "ReactConf AU",


### PR DESCRIPTION
The conference is planned for January, not February.