### PR TITLE
Update CFP end dates

### DIFF
--- a/conferences/2020/php.json
+++ b/conferences/2020/php.json
@@ -66,7 +66,7 @@
     "country": "U.S.A.",
     "twitter": "@midwestphp",
     "cfpUrl": "https://midwestphp.org/cfp",
-    "cfpEndDate": "2019-12-31"
+    "cfpEndDate": "2019-11-30"
   },
   {
     "name": "TYPO3Camp Vienna",
@@ -149,7 +149,7 @@
     "country": "Netherlands",
     "twitter": "@dpcon",
     "cfpUrl": "https://cfp.phpconference.nl",
-    "cfpEndDate": "2020-03-01"
+    "cfpEndDate": "2020-01-28"
   },
   {
     "name": "SymfonyCon Paris 2020",


### PR DESCRIPTION
Midwest PHP conference ended 2019-11-30:

![image](https://user-images.githubusercontent.com/1888809/71138706-2d432000-21c1-11ea-80b1-243564e741cf.png)

Dutch PHP conference ends 2020-01-28

![image](https://user-images.githubusercontent.com/1888809/71138719-392ee200-21c1-11ea-80f5-a88fbe8dc836.png)