### PR TITLE
fixing invalid JSON syntax

### DIFF
--- a/conferences/2020/product.json
+++ b/conferences/2020/product.json
@@ -79,7 +79,7 @@
     "startDate": "2020-04-16",
     "endDate": "2020-04-16",
     "city": "Boston",
-    "country": "U.S.A."
+    "country": "U.S.A.",
     "twitter": "@product_craft"
   },
   {  


### PR DESCRIPTION
Error: Parse error on line 81:
...ountry": "U.S.A."		"twitter": "@product
----------------------^
Expecting 'EOF', '}', ':', ',', ']', got 'STRING'