### PR TITLE
Updated Atlanta Conferences

### DIFF
--- a/conferences/2020/general.json
+++ b/conferences/2020/general.json
@@ -473,17 +473,6 @@
     "twitter": "@NDC_Conferences"
   },
   {
-    "name": "REFACTR.TECH",
-    "url": "https://refactr.tech",
-    "startDate": "2020-04-22",
-    "endDate": "2020-04-24",
-    "city": "Atlanta, GA ",
-    "country": "U.S.A.",
-    "twitter": "@RefactrTech",
-    "cfpUrl": "https://refactr.tech/call-for-speakers.html",
-    "cfpEndDate": "2019-11-01"
-  },
-  {
     "name": "ML Summit",
     "url": "https://ml-summit.de",
     "startDate": "2020-04-22",
@@ -949,6 +938,26 @@
     "twitter": "@NDC_Conferences",
     "cfpUrl": "https://ndcmelbourne.com/page/call-for-papers/",
     "cfpEndDate": "2020-04-05"
+  },
+  {
+    "name": "REFACTR.TECH",
+    "url": "https://refactr.tech",
+    "startDate": "2020-08-12",
+    "endDate": "2020-08-14",
+    "city": "Atlanta, GA ",
+    "country": "U.S.A.",
+    "twitter": "@RefactrTech",
+    "cfpUrl": "https://refactr.tech/call-for-speakers.html",
+    "cfpEndDate": "2019-11-01"
+  },
+  {
+    "name": "RenderATL",
+    "url": "https://www.renderatl.com",
+    "startDate": "2020-08-24",
+    "endDate": "2020-08-26",
+    "city": "Atlanta",
+    "country": "U.S.A.",
+    "twitter": "@renderATL"
   },
   {
     "name": "Scenic City Summit",


### PR DESCRIPTION
Updated the dates for Atlanta conferences (Refactr & Render-Atlanta) that have been effected by the coronavirus pandemic