### PR TITLE
Update JS conferences 2021

### DIFF
--- a/conferences/2021/javascript.json
+++ b/conferences/2021/javascript.json
@@ -1,2 +1,11 @@
 [
+      {
+        "name": "JSHeroes",
+        "url": "https://jsheroes.io",
+        "startDate": "2021-04-15",
+        "endDate": "2021-04-16",
+        "city": "Cluj",
+        "country": "Romania",
+        "twitter": "@jsheroes"
+      }
 ]


### PR DESCRIPTION
One event got pushed to '21.