### PR TITLE
Update Scala conferences COVID

### DIFF
--- a/conferences/2020/scala.json
+++ b/conferences/2020/scala.json
@@ -1,22 +1,5 @@
 [
   {
-    "name": "flatMap",
-    "url": "https://2020.flatmap.no",
-    "startDate": "2020-05-14",
-    "endDate": "2020-05-15",
-    "city": "Oslo",
-    "country": "Norway"
-  },
-  {
-    "name": "ScalaDays",
-    "url": "https://www.scaladays.org",
-    "startDate": "2020-05-17",
-    "endDate": "2020-05-20",
-    "city": "Seattle",
-    "country": "U.S.A.",
-    "twitter": "@scaladays"
-  },
-  {
     "name": "ScalaDays",
     "url": "https://www.scaladays.org",
     "startDate": "2020-06-30",


### PR DESCRIPTION
Cancelled:
[flatMap](https://2020.flatmap.no)
[ScalaDays Seattle](https://www.scaladays.org)