### PR TITLE
Update TS conferences COVID

### DIFF
--- a/conferences/2020/typescript.json
+++ b/conferences/2020/typescript.json
@@ -1,22 +1,2 @@
 [
-  {
-    "name": "TSConf JP",
-    "url": "https://www.tsconf.jp/2020",
-    "startDate": "2020-02-22",
-    "endDate": "2020-02-22",
-    "city": "Tokyo",
-    "country": "Japan",
-    "twitter": "@tsconfjp"
-  },
-  {
-    "name": "TSConf:EU",
-    "url": "https://tsconf.eu",
-    "startDate": "2020-03-31",
-    "endDate": "2020-03-31",
-    "city": "Linz",
-    "country": "Austria",
-    "twitter": "@tsconfeu",
-    "cfpUrl": "https://www.papercall.io/tsconfeu-2020",
-    "cfpEndDate": "2020-01-15"
-  }
 ]


### PR DESCRIPTION
[TSConf JP](https://www.tsconf.jp/2020) and [TSConf:EU](https://tsconf.eu) were both cancelled.