### PR TITLE
Changes IoT conferences due to COVID

### DIFF
--- a/conferences/2020/iot.json
+++ b/conferences/2020/iot.json
@@ -14,20 +14,16 @@
     "endDate": "2020-03-04",
     "city": "Essen",
     "country": "Germany",
-    "twitter": "@building_iot",
-    "cfpUrl": "https://www.buildingiot.de/call_for_proposals_en.php",
-    "cfpEndDate": "2019-09-25"
+    "twitter": "@building_iot"
   },
   {
-    "name": "IoTFuse",
-    "url": "https://iotfuse.com/register",
+    "name": "IoTFuse Virtual",
+    "url": "https://iotfuse.com/",
     "startDate": "2020-04-16",
     "endDate": "2020-04-16",
     "city": "Minneapolis",
     "country": "U.S.A.",
-    "twitter": "@iotfuse",
-    "cfpUrl": "https://iotfuse.com",
-    "cfpEndDate": "2020-04-16"
+    "twitter": "@iotfuse"
   },
   {
     "name": "Internet of Things Conference",


### PR DESCRIPTION
IoTFuse goes digital. Removed passed CfP dates.