### PR TITLE
Update Kotlin conferences changes COVID

### DIFF
--- a/conferences/2020/kotlin.json
+++ b/conferences/2020/kotlin.json
@@ -14,9 +14,7 @@
     "endDate": "2020-06-05",
     "city": "Budapest",
     "country": "Hungary",
-    "twitter": "@kotliners",
-    "cfpUrl": "https://www.papercall.io/kotliners-2020",
-    "cfpEndDate": "2020-02-17"
+    "twitter": "@kotliners"
   },
   {
     "name": "KotLand",
@@ -28,16 +26,5 @@
     "twitter": "@land_kot",
     "cfpUrl": "https://www.papercall.io/kotland-kyiv",
     "cfpEndDate": "2020-04-30"
-  },
-  {
-    "name": "KotlinConf",
-    "url": "https://kotlinconf.com",
-    "startDate": "2020-09-09",
-    "endDate": "2020-09-11",
-    "city": "Montreal",
-    "country": "Canada",
-    "twitter": "@kotlinconf",
-    "cfpUrl": "https://sessionize.com/kotlinconf",
-    "cfpEndDate": "2020-03-31"
   }
 ]


### PR DESCRIPTION
[Kotlinconf](https://kotlinconf.com/) has been cancelled.
The Conference for Kotliners organizers have closed ticket sales and are "re-imagining the conference's format".