### PR TITLE
Update .NET conferences 2021

### DIFF
--- a/conferences/2021/dotnet.json
+++ b/conferences/2021/dotnet.json
@@ -1,2 +1,11 @@
 [
+  {
+    "name": "Visual Studio Live! Austin",
+    "url": "https://vslive.com/events/austin-2020/home.aspx",
+    "startDate": "2020-05-10",
+    "endDate": "2020-05-14",
+    "city": "Austin ",
+    "country": "U.S.A.",
+    "twitter": "@vslive"
+  }
 ]


### PR DESCRIPTION
Visual Studio Live! Austin postponed to 2021 because of COVID-19.