### PR TITLE
Update C++ conferences

### DIFF
--- a/conferences/2020/cpp.json
+++ b/conferences/2020/cpp.json
@@ -1,76 +1,12 @@
 [
   {
-    "name": "QtDay",
-    "url": "https://www.qtday.it",
-    "startDate": "2020-03-13",
-    "endDate": "2020-03-14",
-    "city": "Florence",
-    "country": "Italy",
-    "twitter": "@qtdev",
-    "cfpUrl": "https://www.papercall.io/qtday2020",
-    "cfpEndDate": "2020-01-01"
-  },
-  {
-    "name": "ACCU",
-    "url": "https://conference.accu.org",
-    "startDate": "2020-03-24",
-    "endDate": "2020-03-28",
-    "city": "Bristol",
-    "country": "U.K.",
-    "twitter": "@ACCUConf"
-  },
-  {
-    "name": "C++ CoreHard Spring",
-    "url": "https://conference.corehard.by",
-    "startDate": "2020-04-10",
-    "endDate": "2020-04-11",
-    "city": "Minsk",
-    "country": "Belarus",
-    "twitter": "@CoreHardBY",
-    "cfpUrl": "https://forms.gle/1r1qVz44wpaMto47A",
-    "cfpEndDate": "2020-03-15"
-  },
-  {
-    "name": "C++ Russia  Moscow",
-    "url": "https://cppconf-moscow.ru/en",
-    "startDate": "2020-04-27",
-    "endDate": "2020-04-28",
-    "city": "Moscow",
-    "country": "Russia",
-    "twitter": "@cpp_russia",
-    "cfpUrl": "https://cppconf-moscow.ru/en/callforpapers",
-    "cfpEndDate": "2020-02-10"
-  },
-  {
-    "name": "C++Now",
-    "url": "http://cppnow.org",
-    "startDate": "2020-05-03",
-    "endDate": "2020-05-08",
-    "city": "Aspen",
-    "country": "U.S.A.",
-    "twitter": "@cppnow",
-    "cfpUrl": "http://cppnow.org/announcements/2019/12/2020-CfS",
-    "cfpEndDate": "2020-01-22"
-  },
-  {
-    "name": "Qt World Summit",
-    "url": "https://www.qt.io/qtws20",
-    "startDate": "2020-05-12",
-    "endDate": "2020-05-14",
-    "city": "Palm Springs",
-    "country": "U.S.A.",
-    "twitter": "@qtproject"
-  },
-  {
     "name": "Core C++",
     "url": "https://corecpp.org",
     "startDate": "2020-05-25",
     "endDate": "2020-05-27",
     "city": "Tel Aviv",
     "country": "Israel",
-    "twitter": "@corecpp",
-    "cfpUrl": "https://cfs.corecpp.org",
-    "cfpEndDate": "2020-02-15"
+    "twitter": "@corecpp"
   },
   {
     "name": "C++ on Sea",
@@ -79,20 +15,16 @@
     "endDate": "2020-06-10",
     "city": "Folkestone",
     "country": "U.K.",
-    "twitter": "@cpponsea",
-    "cfpUrl": "https://cfp.cpponsea.uk",
-    "cfpEndDate": "2019-11-30"
+    "twitter": "@cpponsea"
   },
   {
-    "name": "CPPP",
-    "url": "https://cppp.fr",
-    "startDate": "2020-06-22",
-    "endDate": "2020-06-23",
-    "city": "Paris",
-    "country": "France",
-    "twitter": "@CpppFr",
-    "cfpUrl": "https://cppp.fr/cfp",
-    "cfpEndDate": "2020-02-29"
+    "name": "C++ Russia  Moscow",
+    "url": "https://cppconf-moscow.ru/en",
+    "startDate": "2020-07-14",
+    "endDate": "2020-07-15",
+    "city": "Moscow",
+    "country": "Russia",
+    "twitter": "@cpp_russia"
   },
   {
     "name": "CppCon",
@@ -102,5 +34,32 @@
     "city": "Denver",
     "country": "U.S.A.",
     "twitter": "@cppcon"
+  },
+  {
+    "name": "Qt World Summit",
+    "url": "https://www.qt.io/qtws20",
+    "startDate": "2020-10-20",
+    "endDate": "2020-10-22",
+    "city": "Palm Springs",
+    "country": "U.S.A.",
+    "twitter": "@qtproject"
+  },
+  {
+    "name": "C++ CoreHard Spring",
+    "url": "https://conference.corehard.by",
+    "startDate": "2020-10-30",
+    "endDate": "2020-10-31",
+    "city": "Minsk",
+    "country": "Belarus",
+    "twitter": "@CoreHardBY"
+  },
+  {
+    "name": "QtDay",
+    "url": "https://www.qtday.it",
+    "startDate": "2020-11-20",
+    "endDate": "2020-11-21",
+    "city": "Florence",
+    "country": "Italy",
+    "twitter": "@qtdev"
   }
 ]


### PR DESCRIPTION
Cancelled: 
[ACCU](https://conference.accu.org)
[C++Now](http://cppnow.org)
[CPPP](https://cppp.fr)

[C++ on Sea](https://cpponsea.uk) temporarily closed ticket sales.