### PR TITLE
Update Security conferences

### DIFF
--- a/conferences/2020/security.json
+++ b/conferences/2020/security.json
@@ -5,9 +5,7 @@
     "startDate": "2020-01-14",
     "endDate": "2020-01-16",
     "city": "Bangkok",
-    "country": "Thailand",
-    "cfpUrl": "https://www.checkpoint.com/cpx/asia",
-    "cfpEndDate": "2020-01-16"
+    "country": "Thailand"
   },
   {
     "name": "osquery@scale",
@@ -15,9 +13,7 @@
     "startDate": "2020-01-22",
     "endDate": "2020-01-23",
     "city": "San Francisco",
-    "country": "U.S.A.",
-    "cfpUrl": "https://www.papercall.io/osqueryatscale-cfp",
-    "cfpEndDate": "2019-12-31"
+    "country": "U.S.A."
   },
   {
     "name": "CPX 360",
@@ -25,9 +21,7 @@
     "startDate": "2020-01-27",
     "endDate": "2020-01-29",
     "city": "New Orleans",
-    "country": "U.S.A.",
-    "cfpUrl": "https://www.checkpoint.com/cpx/americas",
-    "cfpEndDate": "2020-01-29"
+    "country": "U.S.A."
   },
   {
     "name": "ShmooCon",
@@ -43,9 +37,7 @@
     "startDate": "2020-02-04",
     "endDate": "2020-02-06",
     "city": "Vienna",
-    "country": "Austria",
-    "cfpUrl": "https://www.checkpoint.com/cpx/europe",
-    "cfpEndDate": "2020-02-06"
+    "country": "Austria"
   },
   {
     "name": "Financial Cryptography and Data Security",
@@ -53,9 +45,7 @@
     "startDate": "2020-02-10",
     "endDate": "2020-02-14",
     "city": "Sabah",
-    "country": "Malaysia",
-    "cfpUrl": "https://fc20.ifca.ai/codefi",
-    "cfpEndDate": "2020-01-10"
+    "country": "Malaysia"
   },
   {
     "name": "Texas A&M University System Technology Conference",
@@ -91,8 +81,7 @@
     "endDate": "2020-03-21",
     "city": "Sandy, UT",
     "country": "U.S.A.",
-    "twitter": "@BSidesSLC",
-    "cfpUrl": "https://docs.google.com/forms/d/1Ilx2H_mKLXJh5JqBQNJWfRBfH9GrY-FcDVZcYQ58H34"
+    "twitter": "@BSidesSLC"
   },
   {
     "name": "Bsides Rochester",
@@ -101,51 +90,7 @@
     "endDate": "2020-03-21",
     "city": "Rochester, NY",
     "country": "U.S.A.",
-    "twitter": "@BsidesROC",
-    "cfpUrl": "http://bsidesroc.com/cfp",
-    "cfpEndDate": "2020-02-21"
-  },
-  {
-    "name": "BSides Ljubljana",
-    "url": "https://0x7e4.bsidesljubljana.si",
-    "startDate": "2020-04-04",
-    "endDate": "2020-04-04",
-    "city": "Ljubljana",
-    "country": "Slovenia",
-    "twitter": "@BSidesLjubljana",
-    "cfpUrl": "https://0x7e4.bsidesljubljana.si/cfp",
-    "cfpEndDate": "2020-02-10"
-  },
-  {
-    "name": "QuBit Prague",
-    "url": "https://prague.qubitconference.com",
-    "startDate": "2020-09-23",
-    "endDate": "2020-09-24",
-    "city": "Prague",
-    "country": "Czech republic",
-    "twitter": "@QuBitCon "
-  },
-  {
-    "name": "RuhrSec",
-    "url": "https://www.ruhrsec.de/2020",
-    "startDate": "2020-05-05",
-    "endDate": "2020-05-08",
-    "city": "Bochum",
-    "country": "Germany",
-    "twitter": "@ruhrsec",
-    "cfpUrl": "https://www.ruhrsec.de/2020/index.html#cfp",
-    "cfpEndDate": "2020-01-13"
-  },
-  {
-    "name": "PEPR'20",
-    "url": "https://www.usenix.org/conference/pepr20",
-    "startDate": "2020-05-11",
-    "endDate": "2020-05-12",
-    "city": "Santa Clara, CA",
-    "country": "U.S.A.",
-    "twitter": "@PEPR",
-    "cfpUrl": "https://www.usenix.org/conference/pepr20/call-for-participation",
-    "cfpEndDate": "2020-02-21"
+    "twitter": "@BsidesROC"
   },
   {
     "name": "IT Security Summit",
@@ -157,24 +102,6 @@
     "twitter": "@ITSecSummit"
   },
   {
-    "name": "IT Security Summit",
-    "url": "https://it-security-summit.de",
-    "startDate": "2020-05-18",
-    "endDate": "2020-05-20",
-    "city": "München",
-    "country": "Deutschland"
-  },
-  {
-    "name": "SILM  Workshop",
-    "url": "https://silm-workshop-2020.inria.fr",
-    "startDate": "2020-06-19",
-    "endDate": "2020-06-19",
-    "city": "Genova",
-    "country": "Italy",
-    "cfpUrl": "https://silm-workshop-2020.inria.fr/call-for-papers",
-    "cfpEndDate": "2020-03-16"
-  },
-  {
     "name": "BSides Manchester",
     "url": "https://www.bsidesmcr.org.uk",
     "startDate": "2020-08-20",
@@ -183,24 +110,21 @@
     "country": "U.K."
   },
   {
-    "name": "International Conference on Network Security and Computer Engineering",
-    "url": "https://iccait.coreconferences.com",
-    "startDate": "2020-09-08",
-    "endDate": "2020-09-09",
-    "city": "London",
-    "country": "U.K.",
-    "cfpUrl": "https://iccait.coreconferences.com",
-    "cfpEndDate": "2020-08-10"
+    "name": "SILM  Workshop",
+    "url": "https://silm-workshop-2020.inria.fr",
+    "startDate": "2020-09-07",
+    "endDate": "2020-09-11",
+    "city": "Genova",
+    "country": "Italy"
   },
   {
-    "name": "International Conference on Security in Computing and Cloud Computing",
-    "url": "https://icsccc.coreconferences.com",
-    "startDate": "2020-09-08",
-    "endDate": "2020-09-09",
-    "city": "London",
-    "country": "U.K.",
-    "cfpUrl": "https://icsccc.coreconferences.com",
-    "cfpEndDate": "2020-08-10"
+    "name": "QuBit Prague",
+    "url": "https://prague.qubitconference.com",
+    "startDate": "2020-09-23",
+    "endDate": "2020-09-24",
+    "city": "Prague",
+    "country": "Czech republic",
+    "twitter": "@QuBitCon "
   },
   {
     "name": "Balkan Computer Congress - BalCCon2k20",
@@ -210,5 +134,14 @@
     "city": "Novi Sad",
     "country": "Serbia",
     "twitter": "@balcc0n"
-  }
+  },
+  {
+    "name": "PEPR'20",
+    "url": "https://www.usenix.org/conference/pepr20",
+    "startDate": "2020-10-15",
+    "endDate": "2020-10-16",
+    "city": "Santa Clara, CA",
+    "country": "U.S.A.",
+    "twitter": "@PEPR"
+  },
 ]


### PR DESCRIPTION
Removes duplicate. 

[International Conference on Network Security and Computer Engineering](https://iccait.coreconferences.com) and [International Conference on Security in Computing and Cloud Computing](https://icsccc.coreconferences.com) both not responding.

Cancelled:
[BSides Ljubljana](https://0x7e4.bsidesljubljana.si)