### PR TITLE
Update Security conferences 2021

### DIFF
--- a/conferences/2021/security.json
+++ b/conferences/2021/security.json
@@ -1,2 +1,11 @@
 [
+  {
+    "name": "RuhrSec",
+    "url": "https://www.ruhrsec.de/2020",
+    "startDate": "2021-05-18",
+    "endDate": "2021-05-21",
+    "city": "Bochum",
+    "country": "Germany",
+    "twitter": "@ruhrsec"
+  }
 ]


### PR DESCRIPTION
RuhrSec was cancelled for 2020, but published their 2021 date at the same time.