### PR TITLE
Update Product conferences

### DIFF
--- a/conferences/2020/product.json
+++ b/conferences/2020/product.json
@@ -24,9 +24,7 @@
     "endDate": "2020-02-14",
     "city": "Oakland, CA",
     "country": "U.S.A.",
-    "twitter": "@ProductWorld_",
-    "cfpUrl": "https://productworld.co/conference/speakers/apply-to-speak",
-    "cfpEndDate": "2019-11-15"
+    "twitter": "@ProductWorld_"
   },
   {
     "name": "ProductCraft",
@@ -55,34 +53,16 @@
     "twitter": "@_ProjectProduct"
   },
   {
-    "name": "Software Product Management Summit",
-    "url": "https://spmsummit.org",
-    "startDate": "2020-03-24",
-    "endDate": "2020-03-25",
-    "city": "Frankfurt",
-    "country": "Germany",
-    "twitter": "@ispma_org"
-  },
-  {
-    "name": "Mind the Product",
+    "name": "Mind the Product - Online",
     "url": "https://www.mindtheproduct.com/mtpcon/singapore",
     "startDate": "2020-03-30",
-    "endDate": "2020-03-31",
+    "endDate": "2020-04-03",
     "city": "Singapore",
     "country": "Singapore",
     "twitter": "@mindtheproduct‬"
   },
   {
-    "name": "ProductCraft",
-    "url": "https://productcraft.com/conference/london",
-    "startDate": "2020-03-31",
-    "endDate": "2020-03-31",
-    "city": "London",
-    "country": "U.K.",
-    "twitter": "@product_craft"
-  },
-  {
-    "name": "Product Impact",
+    "name": "Product Impact - Online",
     "url": "https://theproductangle.com/product-impact-2020",
     "startDate": "2020-04-01",
     "endDate": "2020-04-01",
@@ -91,19 +71,10 @@
     "twitter": "@theproductangle"
   },
   {
-    "name": "ProductCraft",
-    "url": "https://productcraft.com/conference",
-    "startDate": "2020-04-16",
-    "endDate": "2020-04-16",
-    "city": "Boston",
-    "country": "U.S.A.",
-    "twitter": "@product_craft"
-  },
-  {
     "name": "#ProductCon",
     "url": "https://www.productschool.com/productcon/san-francisco",
-    "startDate": "2020-04-16",
-    "endDate": "2020-04-16",
+    "startDate": "2020-10-01",
+    "endDate": "2020-10-01",
     "city": "San Francisco",
     "country": "U.S.A.",
     "twitter": "@productschool"
@@ -111,14 +82,14 @@
   {
     "name": "Front",
     "url": "https://www.frontutah.com/conference",
-    "startDate": "2020-05-28",
-    "endDate": "2020-05-29",
+    "startDate": "2020-11-10",
+    "endDate": "2020-11-13",
     "city": "Salt Lake City, UT",
     "country": "U.S.A."
   },
   {
     "name": "La Product Conf",
-    "url": "https://laproductconf.com",
+    "url": "https://laproductconf.com/lpc-2020/",
     "startDate": "2020-06-04",
     "endDate": "2020-06-04",
     "city": "Paris",
@@ -186,9 +157,7 @@
     "startDate": "2020-09-21",
     "endDate": "2020-09-23",
     "city": "Cleveland, OH",
-    "country": "U.S.A.",
-    "cfpUrl": "https://docs.google.com/forms/d/e/1FAIpQLSfDzls_8G0gVacONoDjTuijWu48oreqbZ8NIDTjpxy3_9WSPQ/viewform",
-    "cfpEndDate": "2020-01-31"
+    "country": "U.S.A."
   },
   {
     "name": "Mind the Product",
@@ -206,9 +175,7 @@
     "endDate": "2020-10-09",
     "city": "Dublin",
     "country": "Ireland",
-    "twitter": "@uxdxconf",
-    "cfpUrl": "https://uxdxconf.com/speak",
-    "cfpEndDate": "2020-02-28"
+    "twitter": "@uxdxconf"
   },
   {
     "name": "#ProductCon",


### PR DESCRIPTION
Postponed until further notice: 
[Software Product Management Summit](https://spmsummit.org)
[ProductCraft](https://productcraft.com/conference/london)