### PR TITLE
Update Data conferences

### DIFF
--- a/conferences/2020/data.json
+++ b/conferences/2020/data.json
@@ -5,9 +5,7 @@
     "startDate": "2020-01-25",
     "endDate": "2020-01-26",
     "city": "zurich",
-    "country": "switzerland",
-    "cfpUrl": "https://cosit2020.org/aiapp/index.html",
-    "cfpEndDate": "2019-11-30"
+    "country": "switzerland"
   },
   {
     "name": "The Deep Learning Summit",
@@ -16,9 +14,7 @@
     "endDate": "2020-01-31",
     "city": "San Francisco",
     "country": "U.S.A.",
-    "twitter": "@teamrework",
-    "cfpUrl": "https://teamrework.wufoo.com/forms/deep-learning-san-francisco-suggest-a-speaker",
-    "cfpEndDate": "2019-12-13"
+    "twitter": "@teamrework"
   },
   {
     "name": "AAAI",
@@ -44,9 +40,7 @@
     "endDate": "2020-03-02",
     "city": "Doha",
     "country": "Qatar",
-    "twitter": "@keynotic",
-    "cfpUrl": "https://www.keynotic.com/AIHQ/register.php",
-    "cfpEndDate": "2020-03-01"
+    "twitter": "@keynotic"
   },
   {
     "name": "Women in Data Science (WiDS)",
@@ -81,9 +75,7 @@
     "endDate": "2020-03-25",
     "city": "San Francisco",
     "country": "U.S.A.",
-    "twitter": "@FlinkForward",
-    "cfpUrl": "https://www.flink-forward.org/sf-2020/call-for-presentations",
-    "cfpEndDate": "2020-01-12"
+    "twitter": "@FlinkForward"
   },
   {
     "name": "Flink Forward San Francisco",
@@ -92,8 +84,7 @@
     "endDate": "2020-03-25",
     "city": "San Francisco ",
     "country": "U.S.A.",
-    "twitter": "@FlinkForward",
-    "cfpUrl": "https://www.flink-forward.org/sf-2020/call-for-presentations"
+    "twitter": "@FlinkForward"
   },
   {
     "name": "Postgres Conference",
@@ -107,33 +98,17 @@
   {
     "name": "Machine Learning Conference",
     "url": "https://mlconference.ai/singapore",
-    "startDate": "2020-03-24",
-    "endDate": "2020-03-26",
+    "startDate": "2020-08-08",
+    "endDate": "2020-08-10",
     "city": "Singapore",
     "country": "Singapore",
     "twitter": "@mlconference"
   },
   {
-    "name": "Nordic PGDay",
-    "url": "https://2020.nordicpgday.org",
-    "startDate": "2020-03-24",
-    "endDate": "2020-03-24",
-    "city": "Helsinki",
-    "country": "Finland"
-  },
-  {
-    "name": "The Turing Presents: AI UK",
-    "url": "https://www.turing.ac.uk/ai-uk#programme",
-    "startDate": "2020-03-24",
-    "endDate": "2020-03-25",
-    "city": "London",
-    "country": "U.K."
-  },
-  {
     "name": "Enterprise Connect",
     "url": "https://www.enterpriseconnect.com/orlando/about-enterprise-connect",
-    "startDate": "2020-03-30",
-    "endDate": "2020-04-02",
+    "startDate": "2020-08-03",
+    "endDate": "2020-08-05",
     "city": "Orlando",
     "country": "U.S.A.",
     "twitter": "@enterprisecon"
@@ -141,50 +116,36 @@
   {
     "name": "SQLbits",
     "url": "https://sqlbits.com",
-    "startDate": "2020-03-31",
-    "endDate": "2020-04-04",
+    "startDate": "2020-09-29",
+    "endDate": "2020-10-03",
     "city": "London",
     "country": "U.K."
   },
   {
-    "name": "Reinforce Conference 2.0",
-    "url": "http://reinforceconf.com",
-    "startDate": "2020-04-06",
-    "endDate": "2020-04-08",
-    "city": "Budapest",
-    "country": "Hungary",
-    "twitter": "@reinforceconf",
-    "cfpEndDate": "2020-04-03"
-  },
-  {
     "name": "ODSC East - Open Data Science Conference",
     "url": "https://odsc.com/boston",
-    "startDate": "2020-04-13",
+    "startDate": "2020-04-14",
     "endDate": "2020-04-17",
-    "city": "Boston",
-    "country": "U.S.A.",
-    "twitter": "@odsc",
-    "cfpUrl": "https://odsc.com/boston/call-for-speakers",
-    "cfpEndDate": "2019-12-01"
+    "city": "Online",
+    "country": "Online",
+    "twitter": "@odsc"
   },
   {
     "name": "Smart Cities & Mobility Ecosystems Conference",
     "url": "https://oreilly.formulated.by/scme-phoenix-2020",
-    "startDate": "2020-04-15",
-    "endDate": "2020-04-16",
+    "startDate": "2020-10-07",
+    "endDate": "2020-10-08",
     "city": " Phoenix",
     "country": "U.S.A."
   },
   {
     "name": "Southern Data Science Conference",
     "url": "https://www.southerndatascience.com",
-    "startDate": "2020-04-16",
-    "endDate": "2020-04-17",
+    "startDate": "2020-08-12",
+    "endDate": "2020-08-14",
     "city": "Atlanta",
     "country": "U.S.A.",
-    "twitter": "@southerndsc",
-    "cfpUrl": "https://www.southerndatascience.com/submission-guidline20",
-    "cfpEndDate": "2020-01-31"
+    "twitter": "@southerndsc"
   },
   {
     "name": "IEEE Infrastructure Conference",
@@ -193,20 +154,16 @@
     "endDate": "2020-04-30",
     "city": "San Francisco",
     "country": "U.S.A.",
-    "twitter": "@IEEEInfra",
-    "cfpUrl": "https://infrastructure.ieee.org/calls-for-participation",
-    "cfpEndDate": "2020-02-24"
+    "twitter": "@IEEEInfra"
   },
   {
     "name": "OpML'20",
     "url": "https://www.usenix.org/conference/opml20",
-    "startDate": "2020-05-01",
-    "endDate": "2020-05-01",
+    "startDate": "2020-07-30",
+    "endDate": "2020-07-30",
     "city": "Santa Clara, CA",
     "country": "U.S.A.",
-    "twitter": "@OpML",
-    "cfpUrl": "https://www.usenix.org/conference/opml20/call-for-participation",
-    "cfpEndDate": "2020-02-25"
+    "twitter": "@OpML"
   },
   {
     "name": "AI-CRV",
@@ -226,25 +183,12 @@
     "twitter": "@riseofai"
   },
   {
-    "name": "Percona Live",
-    "url": "https://www.percona.com/live",
-    "startDate": "2020-05-18",
-    "endDate": "2020-05-20",
-    "city": "Austin, TX",
-    "country": "U.S.A.",
-    "twitter": "@percona",
-    "cfpUrl": "https://cfp.percona.com",
-    "cfpEndDate": "2020-01-20"
-  },
-  {
     "name": "International Conference on Logic for Programming, Artificial Intelligence and Reasoning",
     "url": "https://easychair.org/smart-program/LPAR23/index.html",
     "startDate": "2020-05-22",
     "endDate": "2020-05-27",
     "city": "Alicante",
-    "country": "Spain",
-    "cfpUrl": "https://easychair.org/cfp/LPAR-23",
-    "cfpEndDate": "2020-02-15"
+    "country": "Spain"
   },
   {
     "name": "eRum",
@@ -258,8 +202,8 @@
   {
     "name": "European Azure Conference",
     "url": "https://www.europeanazureconference.com",
-    "startDate": "2020-06-02",
-    "endDate": "2020-06-04",
+    "startDate": "2020-10-27",
+    "endDate": "2020-10-29",
     "city": "Nice ",
     "country": "France ",
     "twitter": "@europeanazure"
@@ -272,17 +216,6 @@
     "city": "Columbus, OH",
     "country": "U.S.A.",
     "twitter": "@wia_conference"
-  },
-  {
-    "name": "Women in Analytics Conference",
-    "url": "https://womeninanalytics.com",
-    "startDate": "2020-06-03",
-    "endDate": "2020-06-05",
-    "city": "Columbus, OH",
-    "country": "U.S.A.",
-    "twitter": "@wia_conference",
-    "cfpUrl": "https://womeninanalytics.com/call-for-speakers",
-    "cfpEndDate": "2020-02-29"
   },
   {
     "name": "Smart Cities & Mobility Ecosystems Conference",
@@ -323,13 +256,11 @@
   {
     "name": "3rd Middle East Banking AI & Analytics Summit",
     "url": "http://mebankingai.com",
-    "startDate": "2020-06-15",
-    "endDate": "2020-06-16",
+    "startDate": "2020-10-05",
+    "endDate": "2020-10-06",
     "city": "Dubai",
     "country": "United Arab Emirates",
-    "twitter": "@LetsTalkB2B",
-    "cfpUrl": "http://mebankingai.com",
-    "cfpEndDate": "2019-12-16"
+    "twitter": "@LetsTalkB2B"
   },
   {
     "name": "ML Conference Munich",
@@ -352,26 +283,13 @@
     "cfpEndDate": "2020-04-11"
   },
   {
-    "name": "Swiss PGDay",
-    "url": "https://pgday.ch/2020",
-    "startDate": "2020-06-18",
-    "endDate": "2020-06-19",
-    "city": "Zurich",
-    "country": "Switzerland",
-    "twitter": "@swiss_pgday",
-    "cfpUrl": "https://pgday.ch/2020/#tabs-2",
-    "cfpEndDate": "2020-04-17"
-  },
-  {
     "name": "Postgres Vision",
     "url": "https://www.postgresvision.com",
     "startDate": "2020-06-22",
     "endDate": "2020-06-24",
-    "city": "Boston",
-    "country": "U.S.A.",
-    "twitter": "@PostgresVision",
-    "cfpUrl": "https://www.postgresvision.com/call",
-    "cfpEndDate": "2020-02-29"
+    "city": "Online",
+    "country": "Online",
+    "twitter": "@PostgresVision"
   },
   {
     "name": "PGIBZ",
@@ -409,20 +327,16 @@
     "startDate": "2020-07-11",
     "endDate": "2020-07-12",
     "city": "Toronto",
-    "country": "Canada",
-    "cfpUrl": "https://icaita2020.org/cdkp/index.html",
-    "cfpEndDate": "2020-02-29"
+    "country": "Canada"
   },
   {
     "name": "International Conference on Machine Learning",
     "url": "https://icml.cc",
     "startDate": "2020-07-12",
     "endDate": "2020-07-18",
-    "city": "Vienna",
-    "country": "Austria",
-    "twitter": "@icmlconf",
-    "cfpUrl": "https://icml.cc/Conferences/2020/CallForPapers",
-    "cfpEndDate": "2020-02-06"
+    "city": "Online",
+    "country": "Online",
+    "twitter": "@icmlconf"
   },
   {
     "name": "Data Science and Intelligent Systems Conference",
@@ -484,8 +398,8 @@
     "url": "https://latin-r.com",
     "startDate": "2020-10-07",
     "endDate": "2020-10-09",
-    "city": "Montevideo ",
-    "country": "Uruguay ",
+    "city": "Montevideo",
+    "country": "Uruguay",
     "twitter": "@LatinR_Conf",
     "cfpUrl": "https://latin-r.com/blog/presentacion-trabajos",
     "cfpEndDate": "2020-04-30"


### PR DESCRIPTION
TODO: sort by date to avoid duplicates.

Cancelled:
[Nordic PGDay](https://2020.nordicpgday.org)

Postponed until further notice:
[The Turing Presents: AI UK](https://www.turing.ac.uk/ai-uk#programme)
[Reinforce Conference 2.0](http://reinforceconf.com)
[Percona Live](https://www.percona.com/live)

Cancelled:
[Swiss PGDay](https://pgday.ch/2020)