### PR TITLE
Update Networking conferences

### DIFF
--- a/conferences/2020/networking.json
+++ b/conferences/2020/networking.json
@@ -5,9 +5,7 @@
     "startDate": "2020-01-15",
     "endDate": "2020-01-16",
     "city": "Iskandar Malaysia",
-    "country": "Malaysia",
-    "cfpUrl": "https://www.baseconf.com",
-    "cfpEndDate": "2019-12-31"
+    "country": "Malaysia"
   },
   {
     "name": "IndiaOS",
@@ -74,32 +72,19 @@
     "twitter": "@CornellMBA"
   },
   {
-    "name": "Connnectaha",
-    "url": "https://connectaha.com",
-    "startDate": "2020-03-27",
-    "endDate": "2020-03-27",
-    "city": "Omaha, NE",
-    "country": "U.S.A.",
-    "twitter": "@connectaha",
-    "cfpUrl": "https://papercall.io/connectaha-2020",
-    "cfpEndDate": "2019-12-02"
-  },
-  {
     "name": "Women in Tech Summit",
     "url": "https://midatlantic.womenintechsummit.net",
-    "startDate": "2020-04-14",
-    "endDate": "2020-04-15",
+    "startDate": "2020-10-17",
+    "endDate": "2020-10-18",
     "city": "Washington, D.C.",
     "country": "U.S.A.",
-    "twitter": "@womentechsummit",
-    "cfpUrl": "https://docs.google.com/forms/d/e/1FAIpQLSeeUG7SoYSVvbb7hcxV2-ocCDHL7YXEyMCfKOht2ccDvngwaQ/viewform",
-    "cfpEndDate": "2019-09-20"
+    "twitter": "@womentechsummit"
   },
   {
     "name": "Quantum.Tech",
     "url": "http://www.quantumtechcongress.com",
-    "startDate": "2020-04-20",
-    "endDate": "2020-04-22",
+    "startDate": "2020-10-23",
+    "endDate": "2020-10-25",
     "city": "London",
     "country": "U.K.",
     "twitter": "@QuantumTech_"
@@ -107,19 +92,17 @@
   {
     "name": "Women in Tech Summit",
     "url": "http://northeast.womenintechsummit.net",
-    "startDate": "2020-04-23",
-    "endDate": "2020-04-24",
+    "startDate": "2020-11-12",
+    "endDate": "2020-11-13",
     "city": "Philadelphia, PA",
     "country": "U.S.A.",
-    "twitter": "@womentechsummit",
-    "cfpUrl": "https://docs.google.com/forms/d/e/1FAIpQLSeeUG7SoYSVvbb7hcxV2-ocCDHL7YXEyMCfKOht2ccDvngwaQ/viewform",
-    "cfpEndDate": "2019-09-20"
+    "twitter": "@womentechsummit"
   },
   {
     "name": "Lesbians Who Tech & Allies Summit",
     "url": "https://lesbianswhotech.org/sanfrancisco2020",
-    "startDate": "2020-04-23",
-    "endDate": "2020-04-25",
+    "startDate": "2020-08-06",
+    "endDate": "2020-08-07",
     "city": "San Francisco, CA",
     "country": "U.S.A.",
     "twitter": "@lesbiantech",
@@ -128,29 +111,26 @@
   {
     "name": "Girls In Tech Summit",
     "url": "https://www.techgirlz.org/girls-in-tech-summit",
-    "startDate": "2020-04-25",
-    "endDate": "2020-04-25",
+    "startDate": "2020-11-04",
+    "endDate": "2020-11-04",
     "city": "Philadelphia, PA",
     "country": "U.S.A.",
-    "twitter": "@TechGirlzorg",
-    "cfpUrl": "https://www.tfaforms.com/4796753?utm_source=WITS+Master+email+list",
-    "cfpEndDate": "2020-01-30"
+    "twitter": "@TechGirlzorg"
   },
   {
     "name": "Women in Tech Festival",
     "url": "https://siliconvalleyforum.com/women-in-tech-festival",
-    "startDate": "2020-05-01",
-    "endDate": "2020-05-02",
+    "startDate": "2020-07-24",
+    "endDate": "2020-07-25",
     "city": "Mountain View, CA",
     "country": "U.S.A.",
-    "twitter": "@SVForum",
-    "cfpUrl": "https://docs.google.com/forms/d/e/1FAIpQLSefN278jR3Q7WHaamGB1-PO-EKjVxUg6Y-DPzi7O3ad1G4WLg/viewform"
+    "twitter": "@SVForum"  
   },
   {
     "name": "Women of Silicon Valley",
     "url": "https://www.womenofsiliconvalley.com",
-    "startDate": "2020-05-04",
-    "endDate": "2020-05-05",
+    "startDate": "2020-10-15",
+    "endDate": "2020-10-16",
     "city": "Santa Clara, CA",
     "country": "U.S.A.",
     "twitter": "@wintechseries",
@@ -159,13 +139,11 @@
   {
     "name": "Women in Tech Summit",
     "url": "http://midwest.womenintechsummit.net",
-    "startDate": "2020-05-08",
-    "endDate": "2020-05-08",
+    "startDate": "2020-09-25",
+    "endDate": "2020-09-25",
     "city": "Chicago, IL",
     "country": "U.S.A.",
-    "twitter": "@womentechsummit",
-    "cfpUrl": "https://docs.google.com/forms/d/e/1FAIpQLSeeUG7SoYSVvbb7hcxV2-ocCDHL7YXEyMCfKOht2ccDvngwaQ/viewform",
-    "cfpEndDate": "2019-09-20"
+    "twitter": "@womentechsummit"
   },
   {
     "name": "IEEE Women in Engineering International Leadership Conference",
@@ -197,20 +175,10 @@
     "country": "Netherlands"
   },
   {
-    "name": "DevRelCon SF",
-    "url": "https://sf2020.devrel.net",
-    "startDate": "2020-06-01",
-    "endDate": "2020-06-02",
-    "city": "San Francisco, CA",
-    "country": "U.S.A.",
-    "cfpUrl": "https://sessionize.com/devrelcon-san-francisco-2020",
-    "cfpEndDate": "2020-01-05"
-  },
-  {
     "name": "Women Impact Tech",
     "url": "https://womenimpacttech.com/event/seattle2020",
-    "startDate": "2020-06-03",
-    "endDate": "2020-06-03",
+    "startDate": "2020-12-08",
+    "endDate": "2020-12-08",
     "city": "Seattle, WA",
     "country": "U.S.A.",
     "twitter": "@womenimpacttech"
@@ -218,22 +186,13 @@
   {
     "name": "MODXpo",
     "url": "https://2020.modxpo.eu",
-    "startDate": "2020-06-04",
-    "endDate": "2020-06-05",
+    "startDate": "2020-10-29",
+    "endDate": "2020-10-30",
     "city": "Heidelberg",
     "country": "Germany",
     "twitter": "@MODXpo",
     "cfpUrl": "https://2020.modxpo.eu/cfp",
     "cfpEndDate": "2020-05-01"
-  },
-  {
-    "name": "Viva Technology",
-    "url": "https://vivatechnology.com",
-    "startDate": "2020-06-11",
-    "endDate": "2020-06-13",
-    "city": "Paris",
-    "country": "France",
-    "twitter": "@VivaTech"
   },
   {
     "name": "Women in Technology Summit",


### PR DESCRIPTION
TODO: sort by starting date to avoid duplicates. 

Cancelled:
[Connnectaha](https://connectaha.com)
[DevRelCon SF](https://sf2020.devrel.net)

Postponed until further notice:
[Viva Technology](https://vivatechnology.com)