### PR TITLE
Update ios conferences 2021

### DIFF
--- a/conferences/2021/ios.json
+++ b/conferences/2021/ios.json
@@ -1,2 +1,22 @@
 [
+  {
+    "name": "iOS Conf SG",
+    "url": "https://iosconf.sg",
+    "startDate": "2021-01-20",
+    "endDate": "2021-01-21",
+    "city": "Singapore ",
+    "country": "Singapore",
+    "twitter": "@iosconfsg",
+    "cfpUrl": "https://www.papercall.io/iosconfsg2021",
+    "cfpEndDate": "2020-08-18"
+  },
+  {
+    "name": "ADDC - App Design and Development Conference",
+    "url": "https://addconf.com/",
+    "startDate": "2021-06-23",
+    "endDate": "2021-06-25",
+    "city": "Barcelona ",
+    "country": "Spain",
+    "twitter": "@addconf"
+  }
 ]


### PR DESCRIPTION
iOS Conf Singapore announced their 2021 dates. 
ADDC was pushed to 2021 because of COVID-19.