### PR TITLE
Update ios conferences

### DIFF
--- a/conferences/2020/ios.json
+++ b/conferences/2020/ios.json
@@ -6,9 +6,7 @@
     "endDate": "2020-01-18",
     "city": "Singapore ",
     "country": "Singapore",
-    "twitter": "@iosconfsg",
-    "cfpUrl": "https://www.papercall.io/iosconfsg2020",
-    "cfpEndDate": "2019-09-15"
+    "twitter": "@iosconfsg"
   },
   {
     "name": "dotSwift",
@@ -17,38 +15,7 @@
     "endDate": "2020-02-03",
     "city": "Paris",
     "country": "France",
-    "twitter": "@dotSwift",
-    "cfpUrl": "https://www.dotconferences.com/cfp",
-    "cfpEndDate": "2020-01-01"
-  },
-  {
-    "name": "Appdevcon",
-    "url": "https://appdevcon.nl",
-    "startDate": "2020-03-10",
-    "endDate": "2020-03-13",
-    "city": "Amsterdam",
-    "country": "Netherlands",
-    "twitter": "@AppdevconNL"
-  },
-  {
-    "name": "try! Swift Conference",
-    "url": "https://www.tryswift.co/events/2020/tokyo/en",
-    "startDate": "2020-03-18",
-    "endDate": "2020-03-20",
-    "city": "Tokyo",
-    "country": "Japan",
-    "twitter": "@tryswiftconf"
-  },
-  {
-    "name": "CodeMobile",
-    "url": "http://www.codemobile.co.uk",
-    "startDate": "2020-04-28",
-    "endDate": "2020-04-29",
-    "city": "London",
-    "country": "U.K.",
-    "twitter": "@codemobileuk",
-    "cfpUrl": "http://www.codemobile.co.uk/call-for-speakers",
-    "cfpEndDate": "2019-11-15"
+    "twitter": "@dotSwift"
   },
   {
     "name": "UIKonf",
@@ -57,9 +24,7 @@
     "endDate": "2020-05-20",
     "city": "Berlin",
     "country": "Germany",
-    "twitter": "@uikonf",
-    "cfpUrl": "https://cfp.uikonf.com/",
-    "cfpEndDate": "2020-02-09"
+    "twitter": "@uikonf"
   },
   {
     "name": "Mobius",
@@ -71,17 +36,6 @@
     "twitter": "@MobiusConf",
     "cfpUrl": "https://mobius-piter.ru/en/cfp",
     "cfpEndDate": "2020-04-06"
-  },
-  {
-    "name": "ADDC - App Design and Development Conference",
-    "url": "https://addconf.com/2020",
-    "startDate": "2020-06-24",
-    "endDate": "2020-06-26",
-    "city": "Barcelona ",
-    "country": "Spain",
-    "twitter": "@addconf",
-    "cfpUrl": "https://addconf.typeform.com/to/UYLfhu",
-    "cfpEndDate": "2020-02-15"
   },
   {
     "name": "Hacking with Swift: Live!",
@@ -106,9 +60,16 @@
     "endDate": "2020-09-09",
     "city": "Aberystwyth",
     "country": "U.K.",
-    "twitter": "@IOSDEVUK",
-    "cfpUrl": "https://www.iosdevuk.com/speakercall",
-    "cfpEndDate": "2020-01-31"
+    "twitter": "@IOSDEVUK"
+  },
+  {
+    "name": "Appdevcon",
+    "url": "https://appdevcon.nl",
+    "startDate": "2020-09-15",
+    "endDate": "2020-09-18",
+    "city": "Amsterdam",
+    "country": "Netherlands",
+    "twitter": "@AppdevconNL"
   },
   {
     "name": "#Pragma Conference",


### PR DESCRIPTION
Cancelled:
[try! Swift Conference](https://www.tryswift.co/events/2020/tokyo/en)
[CodeMobile](http://www.codemobile.co.uk)