### PR TITLE
Update DevOps conferences

### DIFF
--- a/conferences/2020/devops.json
+++ b/conferences/2020/devops.json
@@ -250,8 +250,8 @@
     "url": "https://hashiconf.com/digital/",
     "startDate": "2020-06-08",
     "endDate": "2020-06-10",
-    "city": "Amsterdam",
-    "country": "Netherlands",
+    "city": "Online",
+    "country": "Online",
     "twitter": "@HashiConf"
   },
   {
@@ -325,6 +325,24 @@
     "endDate": "2020-08-12",
     "city": "Denver",
     "country": "U.S.A."
+  },
+  {
+    "name": "Cloud Native Rejekts",
+    "url": "https://cloud-native.rejekts.io/",
+    "startDate": "2020-08-11",
+    "endDate": "2020-08-12",
+    "city": "Amsterdam",
+    "country": "Netherlands",
+    "twitter": "@rejektsio"
+  },
+  {
+    "name": "KubeCon + CloudNativeCon Europe 2020",
+    "url": "https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/",
+    "startDate": "2020-08-13",
+    "endDate": "2020-08-16",
+    "city": "Amsterdam",
+    "country": "Netherlands",
+    "twitter": "@Kubecon_"
   },
   {
     "name": "Devopsdays Houston",


### PR DESCRIPTION
Adds KubeCon + Cloud Native Rejekts (projected) new dates.