### PR TITLE
Remove all 2020 O'Reilly conferences

### DIFF
--- a/conferences/2020/data.json
+++ b/conferences/2020/data.json
@@ -131,14 +131,6 @@
     "twitter": "@odsc"
   },
   {
-    "name": "Smart Cities & Mobility Ecosystems Conference",
-    "url": "https://oreilly.formulated.by/scme-phoenix-2020",
-    "startDate": "2020-10-07",
-    "endDate": "2020-10-08",
-    "city": " Phoenix",
-    "country": "U.S.A."
-  },
-  {
     "name": "Southern Data Science Conference",
     "url": "https://www.southerndatascience.com",
     "startDate": "2020-08-12",
@@ -216,14 +208,6 @@
     "city": "Columbus, OH",
     "country": "U.S.A.",
     "twitter": "@wia_conference"
-  },
-  {
-    "name": "Smart Cities & Mobility Ecosystems Conference",
-    "url": "https://oreilly.formulated.by/scme-miami-2020",
-    "startDate": "2020-06-03",
-    "endDate": "2020-06-04",
-    "city": "Miami",
-    "country": "U.S.A."
   },
   {
     "name": "Berlin Buzzwords",
@@ -434,16 +418,6 @@
     "twitter": "@datamindsbe",
     "cfpUrl": "https://sessionize.com/dataminds-connect-2020",
     "cfpEndDate": "2020-05-31"
-  },
-  {
-    "name": "O'Reilly TensorFlow World Conference",
-    "url": "https://conferences.oreilly.com/tensorflow/tf-ca",
-    "startDate": "2020-10-19",
-    "endDate": "2020-10-22",
-    "city": "Santa Clara",
-    "country": "U.S.A.",
-    "twitter": "@TensorFlowWorld",
-    "cfpEndDate": "2020-04-14"
   },
   {
     "name": "Data2Day",

--- a/conferences/2020/devops.json
+++ b/conferences/2020/devops.json
@@ -273,15 +273,6 @@
     "twitter": "@devops_con"
   },
   {
-    "name": "O'Reilly Infrastructure & Ops Conference",
-    "url": "https://conferences.oreilly.com/infrastructure-ops/io-ca",
-    "startDate": "2020-06-15",
-    "endDate": "2020-06-18",
-    "city": "Santa Clara",
-    "country": "U.S.A.",
-    "twitter": "@OReillyInfraOps"
-  },
-  {
     "name": "DevOps Essentials",
     "url": "https://www.devops-essentials.de",
     "startDate": "2020-06-16",
@@ -484,16 +475,6 @@
     "endDate": "2020-10-29",
     "city": "Berlin",
     "country": "Germany"
-  },
-  {
-    "name": "O'Reilly Infrastructure & Ops Conference",
-    "url": "https://conferences.oreilly.com/infrastructure-ops/io-eu",
-    "startDate": "2020-11-16",
-    "endDate": "2020-11-19",
-    "city": "Berlin",
-    "country": "Germany",
-    "twitter": "@OReillyInfraOps",
-    "cfpEndDate": "2020-05-12"
   },
   {
     "name": "DeveloperWeek Austin",

--- a/conferences/2020/general.json
+++ b/conferences/2020/general.json
@@ -140,15 +140,6 @@
     "twitter": "@sinfoist"
   },
   {
-    "name": "O’Reilly Software Architecture Conference",
-    "url": "https://conferences.oreilly.com/software-architecture/sa-ny",
-    "startDate": "2020-02-23",
-    "endDate": "2020-02-26",
-    "city": "New York",
-    "country": "U.S.A.",
-    "twitter": "@OReillySACon"
-  },
-  {
     "name": "ConFoo",
     "url": "https://confoo.ca/en/yul2020",
     "startDate": "2020-02-26",
@@ -593,15 +584,6 @@
     "cfpEndDate": "2020-04-13"
   },
   {
-    "name": "O’Reilly Software Architecture Conference",
-    "url": "https://conferences.oreilly.com/software-architecture/sa-ca",
-    "startDate": "2020-06-15",
-    "endDate": "2020-06-18",
-    "city": "Santa Clara",
-    "country": "U.S.A.",
-    "twitter": "@OReillySACon"
-  },
-  {
     "name": "SREcon20 APAC",
     "url": "https://www.usenix.org/conference/srecon20apac",
     "startDate": "2020-09-07",
@@ -663,15 +645,6 @@
     "city": "Baltimore",
     "country": "U.S.A.",
     "twitter": "@uxpa_int"
-  },
-  {
-    "name": "O'Reilly Open Source Software Conference (OSCON)",
-    "url": "https://conferences.oreilly.com/oscon/oscon-or",
-    "startDate": "2020-07-13",
-    "endDate": "2020-07-16",
-    "city": "Portland",
-    "country": "U.S.A.",
-    "twitter": "@OSCON"
   },
   {
     "name": "ÜberConf",


### PR DESCRIPTION
O'Reilly has shuddered its live conference division and canceled all events

See:
* https://www.oreilly.com/conferences/from-laura-baldwin.html
* https://www.zdnet.com/article/oreilly-closes-the-live-conference-business/