### PR TITLE
Update NL events in dotnet, general, php

### DIFF
--- a/conferences/2020/dotnet.json
+++ b/conferences/2020/dotnet.json
@@ -63,15 +63,6 @@
     "twitter": "@msdev"
   },
   {
-    "name": "Future Tech",
-    "url": "https://futuretech.nl",
-    "startDate": "2020-06-24",
-    "endDate": "2020-06-24",
-    "city": "Utrecht",
-    "country": "Netherlands",
-    "twitter": "@FutureTechNL"
-  },
-  {
     "name": "Visual Studio Live! Microsoft Headquarters",
     "url": "https://vslive.com/events/redmond-2020/home.aspx",
     "startDate": "2020-08-03",
@@ -79,6 +70,15 @@
     "city": "Redmond",
     "country": "U.S.A.",
     "twitter": "@vslive"
+  },
+  {
+    "name": "Future Tech",
+    "url": "https://futuretech.nl",
+    "startDate": "2020-09-16",
+    "endDate": "2020-09-16",
+    "city": "Utrecht",
+    "country": "Netherlands",
+    "twitter": "@FutureTechNL"
   },
   {
     "name": "Basta",

--- a/conferences/2020/general.json
+++ b/conferences/2020/general.json
@@ -637,15 +637,6 @@
     "cfpUrl": "https://website-42889.eventmaker.io/registration/5d8f2e7fd838ff00233f38a6?no_cookie=true"
   },
   {
-    "name": "Joy of Coding",
-    "url": "https://joyofcoding.org",
-    "startDate": "2020-06-19",
-    "endDate": "2020-06-19",
-    "city": "Rotterdam",
-    "country": "Netherlands",
-    "twitter": "@joyofcoding"
-  },
-  {
     "name": "UXPA International Conference",
     "url": "https://uxpa2020.org",
     "startDate": "2020-06-23",

--- a/conferences/2020/php.json
+++ b/conferences/2020/php.json
@@ -128,17 +128,6 @@
     "twitter": "@t3cs"
   },
   {
-    "name": "MageTitans NL",
-    "url": "https://www.mage-titans.nl",
-    "startDate": "2020-06-12",
-    "endDate": "2020-06-12",
-    "city": "Groningen",
-    "country": "Netherlands",
-    "twitter": "@magetitansnl",
-    "cfpUrl": "https://cfp.mage-titans.nl",
-    "cfpEndDate": "2020-03-29"
-  },
-  {
     "name": "CausaConf",
     "url": "https://causaconf.pe/",
     "startDate": "2020-06-13",
@@ -152,10 +141,10 @@
   {
     "name": "Dutch PHP Conference",
     "url": "https://phpconference.nl",
-    "startDate": "2020-06-25",
-    "endDate": "2020-06-27",
-    "city": "Amsterdam",
-    "country": "Netherlands",
+    "startDate": "2020-06-26",
+    "endDate": "2020-06-26",
+    "city": "Online",
+    "country": "Online",
     "twitter": "@dpcon"
   },
   {


### PR DESCRIPTION
php:
Dutch PHP Conference is now online (https://phpconference.nl)
Mage Titans is cancelled (https://www.mage-titans.nl/)

general:
Joy Of Coding is Cancelled, see https://joyofcoding.org

dotnet:
Future Tech has moved to 16-09-2019 (source https://futuretech.nl)