### PR TITLE
Update DevOps conferences 2021

### DIFF
--- a/conferences/2020/devops.json
+++ b/conferences/2020/devops.json
@@ -273,15 +273,6 @@
     "twitter": "@chef"
   },
   {
-    "name": "Paris Container Day",
-    "url": "https://paris-container-day.fr/en/",
-    "startDate": "2020-06-02",
-    "endDate": "2020-06-02",
-    "city": "Paris",
-    "country": "France",
-    "twitter": "@ContainerDayFr"
-  },
-  {
     "name": "DevOps Fest",
     "url": "https://devopsfest.com.ua/indexe.html",
     "startDate": "2020-06-05",

--- a/conferences/2021/devops.json
+++ b/conferences/2021/devops.json
@@ -16,5 +16,14 @@
     "city": "Birmingham",
     "country": "U.K.",
     "twitter": "@TheLeadDev"
+  },
+  {
+    "name": "Paris Container Day",
+    "url": "https://paris-container-day.fr/en/",
+    "startDate": "2021-06-01",
+    "endDate": "2021-06-01",
+    "city": "Paris",
+    "country": "France",
+    "twitter": "@ContainerDayFr"
   }
 ]


### PR DESCRIPTION
Paris Container Day was postponed to 2021.