### PR TITLE
Update Ruby conferences

### DIFF
--- a/conferences/2021/ruby.json
+++ b/conferences/2021/ruby.json
@@ -1,1 +1,11 @@
-[]
+[
+  {
+    "name": "Euruko",
+    "url": "https://euruko2020.org",
+    "startDate": "2021-05-28",
+    "endDate": "2021-05-29",
+    "city": "Helsinki",
+    "country": "Finland",
+    "twitter": "@euruko"
+  }
+]


### PR DESCRIPTION
EuRuKo moved from August 2020, to May 2021.