### PR TITLE
Update Ruby conferences

### DIFF
--- a/conferences/2020/ruby.json
+++ b/conferences/2020/ruby.json
@@ -34,15 +34,6 @@
     "twitter": "@saintprug"
   },
   {
-    "name": "Ruby Unconf Hamburg",
-    "url": "https://2020.rubyunconf.eu/",
-    "startDate": "2020-06-06",
-    "endDate": "2020-06-07",
-    "city": "Hamburg",
-    "country": "Germany",
-    "twitter": "@RubyUnconfEU"
-  },
-  {
     "name": "Brighton Ruby",
     "url": "https://brightonruby.com",
     "startDate": "2020-07-03",
@@ -59,15 +50,6 @@
     "city": "Minsk",
     "country": "Belarus",
     "twitter": "@rubyconfby"
-  },
-  {
-    "name": "Euruko",
-    "url": "https://euruko2020.org",
-    "startDate": "2020-08-21",
-    "endDate": "2020-08-22",
-    "city": "Helsinki",
-    "country": "Finland",
-    "twitter": "@euruko"
   },
   {
     "name": "Ruby Kaigi",


### PR DESCRIPTION
EuRuKo was moved to 2021.
[Ruby Unconf Hamburg](https://2020.rubyunconf.eu/) is cancelled.