### PR TITLE
Update General conferences 2021

### DIFF
--- a/conferences/2021/general.json
+++ b/conferences/2021/general.json
@@ -9,6 +9,14 @@
     "twitter": "@ReactiveConf"
   },
   {
+    "name": "Codemotion",
+    "url": "https://events.codemotion.com/conferences/amsterdam/2020",
+    "startDate": "2021-05-27",
+    "endDate": "2021-05-28",
+    "city": "Amsterdam",
+    "country": "Netherlands"
+  },
+  {
     "name": "Strange Loop",
     "url": "https://thestrangeloop.com",
     "startDate": "2021-09-30",


### PR DESCRIPTION
Codemotion Amsterdam was postponed to 2021. I moved from the "networking" to the "general" category, cause I feel it's more appropriate.