### PR TITLE
Update DevOps conferences

### DIFF
--- a/conferences/2020/devops.json
+++ b/conferences/2020/devops.json
@@ -275,15 +275,15 @@
     "url": "https://devopsfest.com.ua/indexe.html",
     "startDate": "2020-06-05",
     "endDate": "2020-06-06",
-    "city": "Kiev",
-    "country": "Ukraine",
+    "city": "Online",
+    "country": "Online",
     "twitter": "@devopsfest"
   },
   {
     "name": "DevOpsCon Berlin",
     "url": "https://devopscon.io/berlin",
-    "startDate": "2020-06-08",
-    "endDate": "2020-06-11",
+    "startDate": "2020-10-12",
+    "endDate": "2020-10-15",
     "city": "Berlin",
     "country": "Germany",
     "twitter": "@devops_con"
@@ -320,8 +320,8 @@
     "url": "https://stackconf.eu/",
     "startDate": "2020-06-17",
     "endDate": "2020-06-18",
-    "city": "Berlin",
-    "country": "Germany"
+    "city": "Online",
+    "country": "Online"
   },
   {
     "name": "CloudConf",
@@ -385,15 +385,6 @@
     "country": "U.S.A."
   },
   {
-    "name": "Cloud Native Rejekts",
-    "url": "https://cloud-native.rejekts.io/",
-    "startDate": "2020-08-11",
-    "endDate": "2020-08-12",
-    "city": "Online",
-    "country": "Online",
-    "twitter": "@rejektsio"
-  },
-  {
     "name": "KubeCon + CloudNativeCon Europe",
     "url": "https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/",
     "startDate": "2020-08-17",
@@ -410,17 +401,6 @@
     "city": "Houston, TX",
     "country": "U.S.A.",
     "twitter": "@DevOpsDaysHTown"
-  },
-  {
-    "name": "DevOps Talks Conference",
-    "url": "https://devops.talksplus.com/sydney/devops.html",
-    "startDate": "2020-08-24",
-    "endDate": "2020-08-25",
-    "city": "Sydney",
-    "country": "Australia",
-    "cfpUrl": "https://devops.talksplus.com/submit_talk.html",
-    "cfpEndDate": "2020-06-26",
-    "twitter": "@DOTC20"
   },
   {
     "name": "DevOps Fusion",


### PR DESCRIPTION
[Cloud Native Rejekts](https://cloud-native.rejekts.io/) was cancelled. 
[DevOps Talks Conference](https://devops.talksplus.com/sydney/devops.html) was postponed to 2021.