### PR TITLE
Update JavaScript conferences

### DIFF
--- a/conferences/2020/javascript.json
+++ b/conferences/2020/javascript.json
@@ -246,9 +246,7 @@
     "startDate": "2020-05-07",
     "endDate": "2020-05-08",
     "city": "Online",
-    "country": "Online",
-    "cfpUrl": "https://docs.google.com/forms/d/e/1FAIpQLSdhziUY1zUGLT8n0VhSLPiCBnS94-k7518KrAADMqlbbdmiMA/viewform",
-    "cfpEndDate": "2020-04-10",
+    "country": "Online"
     "twitter": "@jsvidcon"
   },
   {
@@ -266,9 +264,7 @@
     "startDate": "2020-05-14",
     "endDate": "2020-05-15",
     "city": "Online",
-    "country": "Online",
-    "cfpUrl": "https://chuck193704.typeform.com/to/XXLjow",
-    "cfpEndDate": "2020-03-31",
+    "country": "Online"
     "twitter": "@jsremoteconf"
   },
   {
@@ -277,9 +273,7 @@
     "startDate": "2020-05-22",
     "endDate": "2020-05-22",
     "city": "Online",
-    "country": "Online",
-    "cfpUrl": "https://halfstackconf.com/online/",
-    "cfpEndDate": "2020-04-15",
+    "country": "Online"
     "twitter": "@halfstackconf"
   },
   {
@@ -310,15 +304,6 @@
     "twitter": "@angularday"
   },
   {
-    "name": "CausaConf",
-    "url": "https://causaconf.pe",
-    "startDate": "2020-06-13",
-    "endDate": "2020-06-13",
-    "city": "Lima",
-    "country": "Peru",
-    "twitter": "@causaconf"
-  },
-  {
     "name": "ReactNext",
     "url": "https://react-next.com",
     "startDate": "2020-06-15",
@@ -330,20 +315,20 @@
   {
     "name": "HolyJS Piter",
     "url": "https://holyjs-piter.ru/en",
-    "startDate": "2020-06-16",
-    "endDate": "2020-06-17",
-    "city": "Saint Petersburg",
-    "country": "Russia",
+    "startDate": "2020-06-22",
+    "endDate": "2020-06-26",
+    "city": "Online",
+    "country": "Online",
     "twitter": "@HolyJSconf"
   },
   {
-    "name": "React Loop",
-    "url": "https://reactloop.com",
-    "startDate": "2020-06-19",
+    "name": "JSNation",
+    "url": "http://jsnation.com",
+    "startDate": "2020-06-18",
     "endDate": "2020-06-19",
-    "city": "Chicago, IL",
-    "country": "U.S.A.",
-    "twitter": "@reactloop"
+    "city": "Online",
+    "country": "Online",
+    "twitter": "@amsterdamjs"
   },
   {
     "name": "JSCONF.BE",
@@ -352,8 +337,6 @@
     "endDate": "2020-06-23",
     "city": "Brussels",
     "country": "Belgium",
-    "cfpUrl": "https://www.jsconf.be/call-for-speakers",
-    "cfpEndDate": "2020-03-31",
     "twitter": "@jsconfbe"
   },
   {
@@ -368,8 +351,8 @@
   {
     "name": "enterJS",
     "url": "https://enterjs.de",
-    "startDate": "2020-06-23",
-    "endDate": "2020-06-26",
+    "startDate": "2020-08-29",
+    "endDate": "2020-10-01",
     "city": "Darmstadt",
     "country": "Germany",
     "twitter": "@enterjsconf"
@@ -390,8 +373,6 @@
     "endDate": "2020-07-05",
     "city": "Odessa",
     "country": "Ukraine",
-    "cfpUrl": "https://docs.google.com/forms/d/e/1FAIpQLSeQqU4iM-vBx6VRWHQcE1zKh3LW4KZ5231Oe0dQx-neBrrc3g/viewform",
-    "cfpEndDate": "2020-05-01",
     "twitter": "@OdessaJS"
   },
   {
@@ -400,9 +381,7 @@
     "startDate": "2020-07-10",
     "endDate": "2020-07-11",
     "city": "Medellin",
-    "country": "Colombia",
-    "cfpUrl": "https://sessionize.com/nodeconfco2020",
-    "cfpEndDate": "2020-04-12",
+    "country": "Colombia"
     "twitter": "@NodeConfCo"
   },
   {
@@ -448,8 +427,6 @@
     "endDate": "2020-08-14",
     "city": "New York, NY",
     "country": "U.S.A.",
-    "cfpUrl": "https://halfstackconf.com/newyork/",
-    "cfpEndDate": "2020-04-30",
     "twitter": "@halfstackconf"
   },
   {

--- a/conferences/2020/javascript.json
+++ b/conferences/2020/javascript.json
@@ -246,7 +246,7 @@
     "startDate": "2020-05-07",
     "endDate": "2020-05-08",
     "city": "Online",
-    "country": "Online"
+    "country": "Online",
     "twitter": "@jsvidcon"
   },
   {
@@ -264,7 +264,7 @@
     "startDate": "2020-05-14",
     "endDate": "2020-05-15",
     "city": "Online",
-    "country": "Online"
+    "country": "Online",
     "twitter": "@jsremoteconf"
   },
   {
@@ -273,7 +273,7 @@
     "startDate": "2020-05-22",
     "endDate": "2020-05-22",
     "city": "Online",
-    "country": "Online"
+    "country": "Online",
     "twitter": "@halfstackconf"
   },
   {
@@ -381,7 +381,7 @@
     "startDate": "2020-07-10",
     "endDate": "2020-07-11",
     "city": "Medellin",
-    "country": "Colombia"
+    "country": "Colombia",
     "twitter": "@NodeConfCo"
   },
   {


### PR DESCRIPTION
[React Loop](https://reactloop.com) was cancelled.
Adds JSNation.