### PR TITLE
enterjs is now an online event

### DIFF
--- a/conferences/2020/javascript.json
+++ b/conferences/2020/javascript.json
@@ -577,8 +577,8 @@
     "url": "https://enterjs.de",
     "startDate": "2020-09-29",
     "endDate": "2020-10-01",
-    "city": "Darmstadt",
-    "country": "Germany",
+    "city": "Online",
+    "country": "Online",
     "twitter": "@enterjsconf"
   },
   {


### PR DESCRIPTION
https://www.heise.de/news/enterJS-2020-Jetzt-als-Online-Konferenz-4856485.html