### PR TITLE
Adds CoC details for 2021 conferences

### DIFF
--- a/conferences/2019/devops.json
+++ b/conferences/2019/devops.json
@@ -954,7 +954,7 @@
     "url": "https://gotocph.com/2019",
     "startDate": "2019-11-18",
     "endDate": "2019-11-22",
-    "city": "Copenhagen ",
+    "city": "Copenhagen",
     "country": "Denmark",
     "twitter": "@gotocph"
   },

--- a/conferences/2020/devops.json
+++ b/conferences/2020/devops.json
@@ -468,9 +468,8 @@
     "endDate": "2020-10-03",
     "city": "Kiev",
     "country": "Ukraine",
-    "cfpUrl": "https://docs.google.com/forms/d/e/1FAIpQLScLAm8Q0FdSzKHC1VGlaHJNTwvwTSk_qDB_NON-8o_FzB2-CQ/viewform",
-    "cfpEndDate": "2020-06-01",
-    "twitter": "@fwdays"
+    "twitter": "@fwdays",
+    "cocUrl": "https://fwdays.com/en/page/code-of-conduct"
   },
   {
     "name": "Speaking About - Web & Mobile development",
@@ -478,7 +477,8 @@
     "startDate": "2020-10-03",
     "endDate": "2020-10-03",
     "city": "Castelo Branco",
-    "country": "Portugal"
+    "country": "Portugal",
+    "cocUrl": "http://speaking.aidicb.pt/anti-harrassment-policy"
   },
   {
     "name": "DevOpsCon Berlin",
@@ -487,7 +487,8 @@
     "endDate": "2020-10-15",
     "city": "Berlin",
     "country": "Germany",
-    "twitter": "@devops_con"
+    "twitter": "@devops_con",
+    "cocUrl": "https://devopscon.io/code-of-conduct/"
   },
   {
     "name": "HashiConf US",
@@ -496,9 +497,8 @@
     "endDate": "2020-10-15",
     "city": "Online",
     "country": "Online",
-    "cfpUrl": "https://sessionize.com/hashiconf-us-2020",
-    "cfpEndDate": "2020-06-23",
-    "twitter": "@hashiconf"
+    "twitter": "@hashiconf",
+    "cocUrl": "https://hashiconf.com/digital-october/code-of-conduct/"
   },
   {
     "name": "DevOps Enterprise Summit",
@@ -506,7 +506,8 @@
     "startDate": "2020-10-13",
     "endDate": "2020-10-15",
     "city": "Online",
-    "country": "Online"
+    "country": "Online",
+    "twitter": "@ITRevDOES"
   },
   {
     "name": "containerday",
@@ -515,17 +516,8 @@
     "endDate": "2020-10-23",
     "city": "Bologna",
     "country": "Italy",
-    "cfpUrl": "https://forms.gle/tGyGBhATWNhVoVd76",
-    "cfpEndDate": "2020-08-31",
-    "twitter": "@containerdayit"
-  },
-  {
-    "name": "DevOpsDays Berlin",
-    "url": "https://devopsdays.org/events/2020-berlin/welcome",
-    "startDate": "2020-10-28",
-    "endDate": "2020-10-29",
-    "city": "Berlin",
-    "country": "Germany"
+    "twitter": "@containerdayit",
+    "cocUrl": "https://2020.containerday.it/coc.html"
   },
   {
     "name": "All Day DevOps",
@@ -534,8 +526,6 @@
     "endDate": "2020-11-13",
     "city": "Online",
     "country": "Online",
-    "cfpUrl": "https://sessionize.com/2020-all-day-devops/",
-    "cfpEndDate": "2020-05-15",
     "twitter": "@alldaydevops"
   },
   {
@@ -545,24 +535,17 @@
     "endDate": "2020-11-18",
     "city": "Austin, TX",
     "country": "U.S.A.",
-    "twitter": "@devweekatx"
+    "twitter": "@devweekatx",
+    "cocUrl": "https://www.devnetwork.com/code-of-conduct/?_ga=2.166983998.1433601102.1601972446-1333229703.1601972446"
   },
   {
     "name": "fin:CODE",
     "url": "https://www.fintech-code.com",
     "startDate": "2020-11-30",
     "endDate": "2020-12-01",
-    "city": "Frankfurt",
+    "city": "Berlin",
     "country": "Germany",
     "twitter": "@weCONECT"
-  },
-  {
-    "name": "devops.barcelona",
-    "url": "https://devops.barcelona",
-    "startDate": "2020-12-14",
-    "endDate": "2020-12-15",
-    "city": "Barcelona",
-    "country": "Spain"
   },
   {
     "name": "Chaos Conf",
@@ -572,8 +555,7 @@
     "city": "Online",
     "country": "Online",
     "twitter": "@chaosconf",
-    "cfpUrl": "https://go.gremlin.com/cc-cfp-2020",
-    "cfpEndDate": "2020-08-14"
+    "cocUrl": "https://res.cloudinary.com/gremlin/image/upload/v1601079832/Chaos%20Conf/Chaos-Conf-Code-of-Conduct.pdf"
   },
   {
     "name": "DevOpsCon Munich Hybrid",
@@ -583,15 +565,16 @@
     "city": "Munich",
     "country": "Germany",
     "twitter": "@devops_con",
-    "cfpUrl": "https://callforpapers.sandsmedia.com"
+    "cfpUrl": "https://callforpapers.sandsmedia.com",
+    "cocUrl": "https://devopscon.io/code-of-conduct/"
   },
   {
-    "name": "cPanel LIVE: MySQL 8 Changes for DBAs and DevOps Webinar with David Stokes of MySQL/Oracle",
+    "name": "cPanel LIVE: The Evolution of NGINX in cPanel",
     "url": "https://www.cpanel.live/home",
-    "startDate": "2020-08-12",
-    "endDate": "2020-08-12",
-    "city": "Houston, TX",
-    "country": "U.S.A.",
+    "startDate": "2020-10-07",
+    "endDate": "2020-10-07",
+    "city": "Online",
+    "country": "Online",
     "twitter": "@cPanel"
   },
   {
@@ -608,10 +591,9 @@
     "url": "https://devopsfest.ru",
     "startDate": "2020-11-06",
     "endDate": "2020-11-07",
-    "city": "Novosibirsk",
-    "country": "Russia",
-    "cfpUrl": "https://hardfest.ru/en#rec216142907",
-    "cfpEndDate": "2020-10-05"
+    "city": "Online",
+    "country": "Online",
+    "cocUrl": "https://2020.devopsfest.ru/en-code-of-conduct"
   },
   {
     "name": "CDCon",
@@ -620,7 +602,8 @@
     "endDate": "2020-10-08",
     "city": "Online",
     "country": "Online",
-    "twitter": "@CDeliveryFdn"
+    "twitter": "@CDeliveryFdn",
+    "cocUrl": "https://events.linuxfoundation.org/cdcon/attend/code-of-conduct/"
   },
   {
     "name": "Unscripted",
@@ -630,8 +613,17 @@
     "city": "Online",
     "country": "Online",
     "twitter": "@unscriptedconf",
-    "cfpUrl": "https://www.papercall.io/unscripted-conf",
-    "cfpEndDate": "2020-08-17"
+    "cocUrl": "https://www.unscriptedconf.io/#Conduct"
+  },
+  {
+    "name": "KubeCon + CloudNativeCon North America 2020",
+    "url": "https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/",
+    "startDate": "2020-11-17",
+    "endDate": "2020-11-20",
+    "city": "Online",
+    "country": "Online",
+    "twitter": "@CloudNativeFdn",
+    "cocUrl": "https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/attend/code-of-conduct/"
   },
   {
     "name": "DevSecOps SKILup Day",

--- a/conferences/2020/general.json
+++ b/conferences/2020/general.json
@@ -1102,17 +1102,8 @@
     "endDate": "2020-10-09",
     "city": "Online",
     "country": "Online",
-    "twitter": "@SlackHQ"
-  },
-  {
-    "name": "Liftoff",
-    "url": "https://www.lift-off.cloud",
-    "startDate": "2020-10-07",
-    "endDate": "2020-10-07",
-    "city": "Zeist",
-    "country": "Netherlands",
-    "cfpUrl": "https://sessionize.com/liftoff",
-    "cfpEndDate": "2020-09-29"
+    "twitter": "@SlackHQ",
+    "cocUrl": "https://slack.com/intl/en-nl/frontiers/faq"
   },
   {
     "name": "Buildstuff Software Development Conference",
@@ -1138,7 +1129,8 @@
     "endDate": "2020-10-01",
     "city": "Online",
     "country": "Online",
-    "twitter": "@ApacheCon"
+    "twitter": "@ApacheCon",
+    "cocUrl": "https://www.apachecon.com/acah2020/conduct.html"
   },
   {
     "name": "Tableau Conference",
@@ -1169,13 +1161,14 @@
     "twitter": "@ActionsOnGoogle"
   },
   {
-    "name": "Power Platform  Community Conference",
+    "name": "Power Platform Community Conference",
     "url": "https://powerplatformconference.splashthat.com",
     "startDate": "2020-10-22",
     "endDate": "2020-10-22",
     "city": "Online",
     "country": "Online",
-    "twitter": "@microsoft"
+    "twitter": "@MSPowerPlat",
+    "cocUrl": "https://powerplatformconference.splashthat.com"
   },
   {
     "name": "Code Together",

--- a/conferences/2020/ruby.json
+++ b/conferences/2020/ruby.json
@@ -101,13 +101,24 @@
     "twitter": "@rubydayit"
   },
   {
+    "name": "ROSS conf",
+    "url": "https://www.rossconf.io/event/remote/",
+    "startDate": "2020-10-23",
+    "endDate": "2020-10-23",
+    "city": "Online",
+    "country": "Online",
+    "twitter": "@rossconf",
+    "cocUrl": "https://www.rossconf.io/event/remote/"
+  },
+  {
     "name": "RubyConf",
     "url": "https://rubyconf.org",
     "startDate": "2020-11-17",
     "endDate": "2020-11-19",
     "city": "Houston, TX",
     "country": "U.S.A.",
-    "twitter": "@rubyconf"
+    "twitter": "@rubyconf",
+    "cocUrl": "https://rubyconf.org/policies"
   },
   {
     "name": "RubyConf Brasil",
@@ -116,8 +127,6 @@
     "endDate": "2020-10-16",
     "city": "Online",
     "country": "Online",
-    "twitter": "@rubyconfbr",
-    "cfpUrl": "https://cfp.rubyconf.com.br",
-    "cfpEndDate": "2020-09-06"
+    "twitter": "@rubyconfbr"
   }
 ]

--- a/conferences/2021/devops.json
+++ b/conferences/2021/devops.json
@@ -34,7 +34,7 @@
     "url": "https://devopsdays.org/events/2021-nashville/welcome/",
     "startDate": "2021-04-01",
     "endDate": "2021-04-02",
-    "city": "Nashville",
+    "city": "Nashville, TN",
     "country": "U.S.A.",
     "twitter": "@nashvilledevops",
     "cocUrl": "https://devopsdays.org/conduct/"
@@ -44,7 +44,7 @@
     "url": "https://devopsdays.org/events/2021-boise/welcome/",
     "startDate": "2021-04-06",
     "endDate": "2021-04-07",
-    "city": "Boise",
+    "city": "Boise, ID",
     "country": "U.S.A.",
     "twitter": "@devopsdaysboise",
     "cocUrl": "https://devopsdays.org/conduct/"

--- a/conferences/2021/devops.json
+++ b/conferences/2021/devops.json
@@ -1,12 +1,13 @@
 [
   {
     "name": "Lead Dev London",
-    "url": "https://wvnts.co/2RnjgtD",
-    "startDate": "2021-02-01",
-    "endDate": "2021-02-02",
+    "url": "https://london2020.theleaddeveloper.com/",
+    "startDate": "2021-06-08",
+    "endDate": "2021-06-09",
     "city": "London",
     "country": "U.K.",
-    "twitter": "@TheLeadDev"
+    "twitter": "@TheLeadDev",
+    "cocUrl": "https://london2020.theleaddeveloper.com/code-of-conduct"
   },
   {
     "name": "Devopsdays Birmingham",
@@ -15,7 +16,68 @@
     "endDate": "2021-03-05",
     "city": "Birmingham",
     "country": "U.K.",
-    "twitter": "@TheLeadDev"
+    "twitter": "@devopsdaysbrum",
+    "cocUrl": "https://devopsdays.org/conduct/"
+  },
+  {
+    "name": "Devopsdays Aarhus",
+    "url": "https://devopsdays.org/events/2021-aarhus/welcome/",
+    "startDate": "2021-04-01",
+    "endDate": "2021-04-02",
+    "city": "Aarhus",
+    "country": "Denmark",
+    "twitter": "@devopsdayscph",
+    "cocUrl": "https://devopsdays.org/conduct/"
+  },  
+  {
+    "name": "Devopsdays Nashville",
+    "url": "https://devopsdays.org/events/2021-nashville/welcome/",
+    "startDate": "2021-04-01",
+    "endDate": "2021-04-02",
+    "city": "Nashville",
+    "country": "U.S.A.",
+    "twitter": "@nashvilledevops",
+    "cocUrl": "https://devopsdays.org/conduct/"
+  },
+  {
+    "name": "Devopsdays Boise",
+    "url": "https://devopsdays.org/events/2021-boise/welcome/",
+    "startDate": "2021-04-06",
+    "endDate": "2021-04-07",
+    "city": "Boise",
+    "country": "U.S.A.",
+    "twitter": "@devopsdaysboise",
+    "cocUrl": "https://devopsdays.org/conduct/"
+  },
+  {
+    "name": "Devopsdays Zurich (Winterthur)",
+    "url": "https://devopsdays.org/events/2021-zurich/welcome/",
+    "startDate": "2021-04-21",
+    "endDate": "2021-04-22",
+    "city": "Zurich",
+    "country": "Switzerland",
+    "twitter": "@DevOpsZH",
+    "cocUrl": "https://devopsdays.org/conduct/"
+  },
+  {
+    "name": "Devopsdays Paris",
+    "url": "https://devopsdays.org/events/2021-paris/welcome/",
+    "startDate": "2021-05-18",
+    "endDate": "2021-05-18",
+    "city": "Paris",
+    "country": "France",
+    "twitter": "@devopsdaysparis",
+    "cocUrl": "https://devopsdays.org/conduct/"
+  },
+  {
+    "name": "Devopsdays Portugal",
+    "url": "https://devopsdays.org/events/2021-portugal/welcome/",
+    "startDate": "2021-05-24",
+    "endDate": "2021-05-25",
+    "city": "Porto",
+    "country": "Portugal",
+    "twitter": "@devopsdayspt",
+    "cocUrl": "https://devopsdays.org/conduct/"
   },
   {
     "name": "DevOps Talks Conference",
@@ -25,7 +87,8 @@
     "city": "Sydney",
     "country": "Australia",
     "cfpUrl": "https://devops.talksplus.com/submit_talk.html",
-    "twitter": "@DOTC20"
+    "twitter": "@DOTC20",
+    "cocUrl": "https://devops.talksplus.com/au/code-of-conduct.html"
   },
   {
     "name": "Paris Container Day",

--- a/conferences/2021/dotnet.json
+++ b/conferences/2021/dotnet.json
@@ -6,7 +6,8 @@
     "endDate": "2021-02-20",
     "city": "Iasi",
     "country": "Romania",
-    "twitter": "@dotnetdaysro"
+    "twitter": "@dotnetdaysro",
+    "cocUrl": "https://dotnetdays.ro/2020/Home/CodeOfConduct"
   },
   {
     "name": "Visual Studio Live! Microsoft Headquarters",
@@ -15,7 +16,8 @@
     "endDate": "2021-08-13",
     "city": "Redmond, WA",
     "country": "U.S.A.",
-    "twitter": "@vslive"
+    "twitter": "@vslive",
+    "cocUrl": "https://vslive.com/pages/harassment.aspx"
   },
   {
     "name": "Visual Studio Live! San Diego",
@@ -24,6 +26,7 @@
     "endDate": "2021-09-16",
     "city": "San Diego, CA",
     "country": "U.S.A.",
-    "twitter": "@vslive"
+    "twitter": "@vslive",
+    "cocUrl": "https://vslive.com/pages/harassment.aspx"
   }
 ]

--- a/conferences/2021/general.json
+++ b/conferences/2021/general.json
@@ -16,7 +16,8 @@
     "endDate": "2021-03-09",
     "city": "Prague",
     "country": "Czech Republic",
-    "twitter": "@ReactiveConf"
+    "twitter": "@ReactiveConf",
+    "cocUrl": "https://reactiveconf.com/code-of-conduct/"
   },
   {
     "name": "Devoxx",
@@ -25,7 +26,8 @@
     "endDate": "2021-04-09",
     "city": "Paris",
     "country": "France",
-    "twitter": "@DevoxxFR"
+    "twitter": "@DevoxxFR",
+    "cocUrl": "https://www.devoxx.fr/code-of-conduct/"
   },
   {
     "name": "Codemotion",
@@ -33,7 +35,8 @@
     "startDate": "2021-05-27",
     "endDate": "2021-05-28",
     "city": "Amsterdam",
-    "country": "Netherlands"
+    "country": "Netherlands",
+    "cocUrl": "https://events.codemotion.com/conferences/amsterdam/2020/news/codemotion-is-an-inclusive-conference-check-our-coc/"
   },
   {
     "name": "DevBreak",
@@ -42,7 +45,8 @@
     "endDate": "2021-06-18",
     "city": "Bouville",
     "country": "France",
-    "twitter": "@DevBreak20"
+    "twitter": "@DevBreak20",
+    "cocUrl": "https://www.devbreak.io/code-of-conduct"
   },
   {
     "name": "Web Summer Camp",
@@ -51,7 +55,8 @@
     "endDate": "2021-08-27",
     "city": "Bol",
     "country": "Croatia",
-    "twitter": "@WebSummerCamp"
+    "twitter": "@WebSummerCamp",
+    "cocUrl": "https://2021.websummercamp.com/code-of-conduct"
   },
   {
     "name": "REFACTR.TECH",
@@ -60,7 +65,8 @@
     "endDate": "2021-09-17",
     "city": "Atlanta, GA",
     "country": "U.S.A.",
-    "twitter": "@RefactrTech"
+    "twitter": "@RefactrTech",
+    "cocUrl": "https://www.refactr.tech/code-of-conduct/"
   },
   {
     "name": "AdaLoversConf",
@@ -80,7 +86,8 @@
     "country": "U.S.A.",
     "cfpUrl": "https://thestrangeloop.com/cfp.html",
     "cfpEndDate": "2021-04-30",
-    "twitter": "@strangeloop_stl"
+    "twitter": "@strangeloop_stl",
+    "cocUrl": "https://thestrangeloop.com/policies.html"
   },
   {
     "name": "ITNEXT Summit",
@@ -89,7 +96,8 @@
     "endDate": "2021-10-27",
     "city": "Amsterdam",
     "country": "Netherlands",
-    "twitter": "@itnext_io"
+    "twitter": "@itnext_io",
+    "cocUrl": "https://www.itnextsummit.com/wp-content/uploads/2019/01/code-of-conduct.pdf"
   },
   {
     "name": "HackConf",
@@ -100,7 +108,8 @@
     "country": "Bulgaria",
     "twitter": "@HackConf_",
     "cfpUrl": "https://www.hackconf.bg/#cfs",
-    "cfpEndDate": "2021-04-30"
+    "cfpEndDate": "2021-04-30",
+    "cocUrl": "https://drive.google.com/file/d/1YTce-qmjSxroN5vK9jthXZCWthlr0ul-/view"
   },
   {
     "name": "Conf42: Cloud Native",
@@ -144,7 +153,8 @@
     "country": "Australia",
     "twitter": "@VoxxedAustralia",
     "cfpUrl": "https://vxmelb21.cfp.dev",
-    "cfpEndDate": "2021-03-31"
+    "cfpEndDate": "2021-03-31",
+    "cocUrl": "https://australia.voxxeddays.com/code-of-conduct/"
   },
   {
     "name": "DeveloperWeek",

--- a/conferences/2021/ios.json
+++ b/conferences/2021/ios.json
@@ -8,7 +8,8 @@
     "country": "Singapore",
     "cfpUrl": "https://www.papercall.io/iosconfsg2021",
     "cfpEndDate": "2020-08-18",
-    "twitter": "@iosconfsg"
+    "twitter": "@iosconfsg",
+    "cocUrl": "https://2020.iosconf.sg/cod/"
   },
   {
     "name": "ADDC - App Design and Development Conference",

--- a/conferences/2021/java.json
+++ b/conferences/2021/java.json
@@ -6,7 +6,8 @@
     "endDate": "2021-03-10",
     "city": "Tel Aviv",
     "country": "Israel",
-    "twitter": "@NodeTLV"
+    "twitter": "@NodeTLV",
+    "cocUrl": "https://www.nodetlv.com/code-of-conduct"
   },
   {
     "name": "Conf42: Java",

--- a/conferences/2021/javascript.json
+++ b/conferences/2021/javascript.json
@@ -8,7 +8,8 @@
     "country": "U.S.A.",
     "cfpUrl": "https://halfstackconf.com/phoenix/",
     "cfpEndDate": "2020-08-31",
-    "twitter": "@halfstackconf"
+    "twitter": "@halfstackconf",
+    "cocUrl": "https://halfstackconf.com/phoenix/code-of-conduct/"
   },
   {
     "name": "ReactiveConf",
@@ -19,7 +20,8 @@
     "country": "Czech Republic",
     "cfpUrl": "https://reactiveconf.com/speaker",
     "cfpEndDate": "2020-11-01",
-    "twitter": "@ReactiveConf"
+    "twitter": "@ReactiveConf",
+    "cocUrl": "https://reactiveconf.com/code-of-conduct/"
   },
   {
     "name": "JSHeroes",
@@ -28,7 +30,8 @@
     "endDate": "2021-04-16",
     "city": "Cluj-Napoca",
     "country": "Romania",
-    "twitter": "@jsheroes"
+    "twitter": "@jsheroes",
+    "cocUrl": "https://jsheroes.io/code-of-conduct"
   },
   {
     "name": "LvivJS",
@@ -37,7 +40,8 @@
     "endDate": "2021-06-06",
     "city": "Lviv",
     "country": "Ukraine",
-    "twitter": "@LvivJS"
+    "twitter": "@LvivJS",
+    "cocUrl": "https://lvivjs.org.ua/code_of_conduct.html"
   },
   {
     "name": "React Day Norway",
@@ -46,7 +50,8 @@
     "endDate": "2021-06-18",
     "city": "Larvik",
     "country": "Norway",
-    "twitter": "@ReactNorway"
+    "twitter": "@ReactNorway",
+    "cocUrl": "https://berlincodeofconduct.org/"
   },
   {
     "name": "HalfStack Newquay",
@@ -57,7 +62,8 @@
     "country": "U.K.",
     "cfpUrl": "https://halfstackconf.com/newquay/",
     "cfpEndDate": "2021-03-15",
-    "twitter": "@halfstackconf"
+    "twitter": "@halfstackconf",
+    "cocUrl": "https://halfstackconf.com/newquay/code-of-conduct/"
   },
   {
     "name": "JSCAMP",
@@ -66,7 +72,8 @@
     "endDate": "2021-07-16",
     "city": "Barcelona",
     "country": "Spain",
-    "twitter": "@jscamp"
+    "twitter": "@jscamp",
+    "cocUrl": "https://jscamp.tech/code-of-conduct/"
   },
   {
     "name": "React Day New York",
@@ -75,7 +82,8 @@
     "endDate": "2021-09-10",
     "city": "Brooklyn, NY",
     "country": "U.S.A.",
-    "twitter": "@ReactNewYork"
+    "twitter": "@ReactNewYork",
+    "cocUrl": "https://berlincodeofconduct.org/"
   },
   {
     "name": "Nordic.js",
@@ -85,7 +93,8 @@
     "city": "Stockholm",
     "country": "Sweden",
     "cfpUrl": "https://nordicjs.com/call-for-speakers",
-    "twitter": "@nordicjs"
+    "twitter": "@nordicjs",
+    "cocUrl": "https://nordicjs.com/code-of-conduct"
   },
   {
     "name": "Conf42: JavaScript",

--- a/conferences/2021/leadership.json
+++ b/conferences/2021/leadership.json
@@ -8,6 +8,7 @@
     "country": "Germany",
     "twitter": "@ama_conf",
     "cfpUrl": "https://agile-meets-architecture.com/call-for-proposals",
-    "cfpEndDate": "2020-08-31"
+    "cfpEndDate": "2020-08-31",
+    "cocUrl": "https://agile-meets-architecture.com/code-of-conduct"
   }
 ]

--- a/conferences/2021/php.json
+++ b/conferences/2021/php.json
@@ -8,6 +8,7 @@
     "country": "Canada",
     "twitter": "@confooca",
     "cfpUrl": "https://confoo.ca/en/yul2021/call-for-papers",
-    "cfpEndDate": "2020-10-16"
+    "cfpEndDate": "2020-10-16",
+    "cocUrl": "https://confoo.ca/en/code-of-conduct"
   }
 ]

--- a/conferences/2021/product.json
+++ b/conferences/2021/product.json
@@ -6,7 +6,8 @@
     "endDate": "2021-02-09",
     "city": "London",
     "country": "U.K.",
-    "twitter": "@productschool"
+    "twitter": "@productschool",
+    "cocUrl": "https://productschool.com/code-of-conduct/"
   },
   {
     "name": "Mind the Product",
@@ -15,7 +16,8 @@
     "endDate": "2021-03-19",
     "city": "Singapore",
     "country": "Singapore",
-    "twitter": "@MindtheProduct"
+    "twitter": "@MindtheProduct",
+    "cocUrl": "https://www.mindtheproduct.com/code-of-conduct/"
   },
   {
     "name": "#ProductCon",
@@ -24,7 +26,8 @@
     "endDate": "2021-04-08",
     "city": "San Francisco, CA",
     "country": "U.S.A.",
-    "twitter": "@productschool"
+    "twitter": "@productschool",
+    "cocUrl": "https://productschool.com/code-of-conduct/"
   },
   {
     "name": "European Product Owner & Requirements Engineering Day",

--- a/conferences/2021/ruby.json
+++ b/conferences/2021/ruby.json
@@ -6,6 +6,7 @@
     "endDate": "2021-05-29",
     "city": "Helsinki",
     "country": "Finland",
-    "twitter": "@euruko"
+    "twitter": "@euruko",
+    "cocUrl": "https://euruko2021.org/code_of_conduct/"
   }
 ]

--- a/conferences/2021/security.json
+++ b/conferences/2021/security.json
@@ -6,6 +6,7 @@
     "endDate": "2021-05-21",
     "city": "Bochum",
     "country": "Germany",
-    "twitter": "@ruhrsec"
+    "twitter": "@ruhrsec",
+    "cocUrl": "https://www.ruhrsec.de/2020/codeofconduct.html"
   }
 ]

--- a/conferences/2021/ux.json
+++ b/conferences/2021/ux.json
@@ -6,7 +6,8 @@
     "endDate": "2021-03-18",
     "city": "Birmingham",
     "country": "U.K.",
-    "twitter": "@canvasconf"
+    "twitter": "@canvasconf",
+    "cocUrl": "https://docs.google.com/document/d/1E5eiXx868wRSLvExCctywlVulSUkFjlTX2J1PwM_aPA/edit"
   },
   {
     "name": "CSSCAMP",
@@ -15,7 +16,8 @@
     "endDate": "2021-07-14",
     "city": "Barcelona",
     "country": "Spain",
-    "twitter": "@csscamp"
+    "twitter": "@csscamp",
+    "cocUrl": "https://csscamp.tech/code-of-conduct/"
   },
   {
     "name": "An Event Apart Orlando",
@@ -24,7 +26,8 @@
     "endDate": "2021-09-01",
     "city": "Orlando, FL",
     "country": "U.S.A.",
-    "twitter": "@aneventapart"
+    "twitter": "@aneventapart",
+    "cocUrl": "https://aneventapart.com/registration-information#code-of-conduct"
   },
   {
     "name": "CanUX",
@@ -33,7 +36,8 @@
     "endDate": "2021-11-07",
     "city": "Ottawa",
     "country": "Canada",
-    "twitter": "@canuxconf"
+    "twitter": "@canuxconf",
+    "cocUrl": "https://canux.io/about/code-of-conduct/"
   },
   {
     "name": "UXOK",
@@ -44,7 +48,8 @@
     "country": "U.S.A.",
     "twitter": "@uxokconf",
     "cfpUrl": "https://www.papercall.io/uxok-2021",
-    "cfpEndDate": "2020-10-01"
+    "cfpEndDate": "2020-10-01",
+    "cocUrl": "https://www.techlahoma.org/code-of-conduct"
   },
   {
     "name": "axe-con",

--- a/config/validLocations.js
+++ b/config/validLocations.js
@@ -122,8 +122,8 @@ module.exports = {
     "Prague"
   ],
   "Denmark": [
-    "Copenhagen",
-    "Copenhagen "
+    "Aarhus",
+    "Copenhagen"
   ],
   "Dominican Republic": [
     "Punta Cana",


### PR DESCRIPTION
As per #2284 : updates 2021 conferences across topics.
Also adds several devopsdays events for 2021. 