### PR TITLE
Update Rust conferences

### DIFF
--- a/conferences/2021/rust.json
+++ b/conferences/2021/rust.json
@@ -1,1 +1,10 @@
-[]
+[
+  {
+    "name": "RustLab",
+    "url": "https://rustlab.it/en/",
+    "startDate": "2021-01-03",
+    "endDate": "2021-01-03",
+    "online": true,
+    "cfpUrl": "https://rustlab.it/en/call-for-proposal/"
+  }
+]


### PR DESCRIPTION
RustLab will have several dates throughout the year, *starting from March* which is why I set the `startDate` for March 1. CfP is open all year round. My guess is that RustLab isn't the only conference changing up its format. DevRelCon 2020 comes to mind. What's your guidance?