### PR TITLE
remove the duplicate DevOps.js Conference

### DIFF
--- a/conferences/2021/javascript.json
+++ b/conferences/2021/javascript.json
@@ -94,14 +94,6 @@
     "cocUrl": "https://reactiveconf.com/code-of-conduct/"
   },
   {
-    "name": "DevOps.js Conference",
-    "url": "https://www.devopsjsconf.com/",
-    "startDate": "2021-03-10",
-    "endDate": "2021-03-11",
-    "online": true,
-    "cocUrl": "https://devopsjsconf.com/coc"
-  },
-  {
     "name": "Angular Days",
     "url": "https://javascript-days.de/angular",
     "startDate": "2021-03-22",


### PR DESCRIPTION
it was happening on 29&30 of this March, there was no duplicate DevOps.js Conference in the same month

```json
  {
    "name": "DevOps.js Conference",
    "url": "https://devopsjsconf.com",
    "startDate": "2021-03-29",
    "endDate": "2021-03-30",
    "online": true,
    "cfpUrl": "https://forms.gle/4kwg6NSCWRfPEdAx6",
    "cfpEndDate": "2021-02-15",
    "twitter": "@devopsjs",
    "cocUrl": "https://devopsjsconf.com/coc",
    "offersSignLanguageOrCC": false
  },
```