### PR TITLE
Get rid of LvivJS

### DIFF
--- a/conferences/2021/javascript.json
+++ b/conferences/2021/javascript.json
@@ -311,16 +311,6 @@
     "twitter": "@fwdays"
   },
   {
-    "name": "LvivJS",
-    "url": "https://lvivjs.org.ua",
-    "startDate": "2021-06-06",
-    "endDate": "2021-06-06",
-    "city": "Lviv",
-    "country": "Ukraine",
-    "twitter": "@LvivJS",
-    "cocUrl": "https://lvivjs.org.ua/code_of_conduct.html"
-  },
-  {
     "name": "OpenJS World",
     "url": "https://openjsf.org/openjs-world-2021/",
     "startDate": "2021-06-09",


### PR DESCRIPTION
No longer a valid conference: https://github.com/tech-conferences/conference-data/issues/3345