### PR TITLE
Update JSConf Budapest

### DIFF
--- a/conferences/2021/javascript.json
+++ b/conferences/2021/javascript.json
@@ -473,18 +473,6 @@
     "offersSignLanguageOrCC": true
   },
   {
-    "name": "JSConf Budapest",
-    "url": "https://jsconfbp.com",
-    "startDate": "2021-09-23",
-    "endDate": "2021-09-24",
-    "city": "Budapest",
-    "country": "Hungary",
-    "online": false,
-    "cfpUrl": "https://jsconfbp.com/call-for-speakers-2021",
-    "cfpEndDate": "2021-03-31",
-    "twitter": "@jsconfbp"
-  },
-  {
     "name": "International JavaScript Conference New York",
     "url": "https://javascript-conference.com/new-york",
     "startDate": "2021-09-27",

--- a/conferences/2022/javascript.json
+++ b/conferences/2022/javascript.json
@@ -1,5 +1,15 @@
 [
   {
+    "name": "JSConf Budapest",
+    "url": "https://jsconfbp.com",
+    "startDate": "2022-06-02",
+    "endDate": "2022-06-03",
+    "city": "Budapest",
+    "country": "Hungary",
+    "online": false,
+    "twitter": "@jsconfbp"
+  },
+  {
     "name": "HalfStack Newquay",
     "url": "https://halfstackconf.com/newquay/",
     "startDate": "2022-07-01",


### PR DESCRIPTION
See announcement https://jsconfbp.com/updates/postpone-to-2022