### PR TITLE
Remove Conference From List

### DIFF
--- a/conferences/2021/javascript.json
+++ b/conferences/2021/javascript.json
@@ -535,18 +535,6 @@
     "cocUrl": "https://emberfest.eu/code-of-conduct/"
   },
   {
-    "name": "Vue Global",
-    "url": "https://vuejs.amsterdam",
-    "startDate": "2021-10-01",
-    "endDate": "2021-10-04",
-    "city": "Amsterdam",
-    "country": "Netherlands",
-    "online": true,
-    "cfpUrl": "https://vuejs.amsterdam/code-of-conduct",
-    "cfpEndDate": "2021-09-01",
-    "twitter": "@vuejsamsterdam"
-  },
-  {
     "name": "Angular Days",
     "url": "https://javascript-days.de/angular/",
     "startDate": "2021-10-04",
@@ -588,28 +576,6 @@
     "cfpEndDate": "2021-09-15",
     "twitter": "@ReactNewYork",
     "cocUrl": "https://berlincodeofconduct.org/"
-  },
-  {
-    "name": "JSWorld Conference",
-    "url": "https://jsworldconference.com",
-    "startDate": "2021-10-05",
-    "endDate": "2021-10-06",
-    "city": "Amsterdam",
-    "country": "Netherlands",
-    "online": true,
-    "twitter": "@Frontend_Love",
-    "cocUrl": "https://jsworldconference.com/code-of-conduct/"
-  },
-  {
-    "name": "React Conference Live",
-    "url": "https://www.reactlive.nl",
-    "startDate": "2021-10-07",
-    "endDate": "2021-10-08",
-    "city": "Amsterdam",
-    "country": "Netherlands",
-    "online": true,
-    "twitter": "@reactlivenl",
-    "cocUrl": "https://reactlive.nl/code-of-conduct"
   },
   {
     "name": "Vue.js London Conference",


### PR DESCRIPTION
Remove Vue Global, React Conference, and JS World Conference from the list because dates have been updated.