### PR TITLE
Fix typo in `README.md` (Closure -> Clojure)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Conference data have the following structure:
 
 - [See all .NET conferences](https://confs.tech/dotnet)
 - [See all Android conferences](https://confs.tech/android)
-- [See all Closure conferences](https://confs.tech/closure)
+- [See all Clojure conferences](https://confs.tech/clojure)
 - [See all CSS conferences](https://confs.tech/css)
 - [See all Data conferences](https://confs.tech/data)
 - [See all Design / UX conferences](https://confs.tech/ux)


### PR DESCRIPTION
Looking through the [previous conferences listed in this repository](https://github.com/tech-conferences/conference-data/blob/main/conferences/2019/clojure.json), I'm pretty sure that 'Closure' is a typo in the README. Also, as something of a Lisp fan myself, I'd highly recommend that people give this particular category a look! :D