### PR TITLE
Add Longhorn PHP to list of 2022 PHP conferences

### DIFF
--- a/conferences/2022/php.json
+++ b/conferences/2022/php.json
@@ -179,6 +179,19 @@
     "cocUrl": "https://phpconference.com/code-of-conduct/"
   },
   {
+    "name": "Longhorn PHP",
+    "url": "https://www.longhornphp.com",
+    "startDate": "2022-11-03",
+    "endDate": "2022-11-05",
+    "city": "Austin, TX",
+    "country": "U.S.A.",
+    "online": false,
+    "cfpUrl": "https://cfp.longhornphp.com",
+    "cfpEndDate": "2022-08-11",
+    "twitter": "@longhornphp",
+    "cocUrl": "https://www.longhornphp.com/code-of-conduct"
+  },
+  {
     "name": "Codeurs en Seine",
     "url": "https://www.codeursenseine.com/2022",
     "startDate": "2022-11-17",


### PR DESCRIPTION
Website: https://www.longhornphp.com
CFP: https://cfp.longhornphp.com
Twitter: https://twitter.com/@longhornphp
```json
  {
    "name": "Longhorn PHP",
    "url": "https://www.longhornphp.com",
    "startDate": "2022-11-03",
    "endDate": "2022-11-05",
    "city": "Austin, TX",
    "country": "U.S.A.",
    "online": false,
    "cfpUrl": "https://cfp.longhornphp.com",
    "cfpEndDate": "2022-08-11"
    "twitter": "@longhornphp",
    "cocUrl": "https://www.longhornphp.com/code-of-conduct"
  },
```