### PR TITLE
Add locales to valid fields

### DIFF
--- a/config/validFields.js
+++ b/config/validFields.js
@@ -10,5 +10,6 @@ module.exports = [
   "cfpEndDate",
   "twitter",
   "cocUrl",
+  "locales",
   "offersSignLanguageOrCC"
 ];


### PR DESCRIPTION
Allowing `locales` field to be passed. Cf: https://github.com/tech-conferences/confs.tech/pull/545