### PR TITLE
Add Refresh for JavaScript, TypeScript, Accessibility, CSS

### DIFF
--- a/conferences/2023/accessibility.json
+++ b/conferences/2023/accessibility.json
@@ -56,5 +56,15 @@
     "online": true,
     "twitter": "@magnoliajsconf",
     "cocUrl": "https://www.magnoliajs.com/conduct"
+  },
+  {
+    "name": "Refresh",
+    "url": "https://refresh.rocks/",
+    "startDate": "2023-01-26",
+    "endDate": "2023-01-27",
+    "city": "Tartu",
+    "country": "Estonia",
+    "online": false,
+    "twitter": "@RefreshRocks"
   }
 ]

--- a/conferences/2023/css.json
+++ b/conferences/2023/css.json
@@ -20,5 +20,15 @@
     "online": true,
     "twitter": "@magnoliajsconf",
     "cocUrl": "https://www.magnoliajs.com/conduct"
+  },
+  {
+    "name": "Refresh",
+    "url": "https://refresh.rocks/",
+    "startDate": "2023-01-26",
+    "endDate": "2023-01-27",
+    "city": "Tartu",
+    "country": "Estonia",
+    "online": false,
+    "twitter": "@RefreshRocks"
   }
 ]

--- a/conferences/2023/javascript.json
+++ b/conferences/2023/javascript.json
@@ -145,5 +145,15 @@
     "cfpEndDate": "2023-10-16",
     "twitter": "@conf42com",
     "cocUrl": "https://www.conf42.com/code-of-conduct"
+  },
+  {
+    "name": "Refresh",
+    "url": "https://refresh.rocks/",
+    "startDate": "2023-01-26",
+    "endDate": "2023-01-27",
+    "city": "Tartu",
+    "country": "Estonia",
+    "online": false,
+    "twitter": "@RefreshRocks"
   }
 ]

--- a/conferences/2023/typescript.json
+++ b/conferences/2023/typescript.json
@@ -46,5 +46,15 @@
     "online": true,
     "twitter": "@magnoliajsconf",
     "cocUrl": "https://www.magnoliajs.com/conduct"
+  },
+  {
+    "name": "Refresh",
+    "url": "https://refresh.rocks/",
+    "startDate": "2023-01-26",
+    "endDate": "2023-01-27",
+    "city": "Tartu",
+    "country": "Estonia",
+    "online": false,
+    "twitter": "@RefreshRocks"
   }
 ]

--- a/config/validLocations.js
+++ b/config/validLocations.js
@@ -143,7 +143,8 @@ module.exports = {
     "Cairo"
   ],
   "Estonia": [
-    "Tallinn"
+    "Tallinn",
+    "Tartu"
   ],
   "Ethiopia": [
     "Addis Ababa"


### PR DESCRIPTION
Refresh is a one-day, three-track conference focusing on front-end development, product development, and design taking place in Tartu, Estonia on Jan 26-27, 2023.

[website](https://refresh.rocks/)
[twitter](https://twitter.com/RefreshRocks)