### PR TITLE
Update devops.json with correct URL for DevOpsDays Birmingham

### DIFF
--- a/conferences/2023/devops.json
+++ b/conferences/2023/devops.json
@@ -304,7 +304,7 @@
   },
   {
     "name": "Devopsdays Birmingham, AL",
-    "url": "https://devopsdays.org/events/2023-nashville/welcome/",
+    "url": "https://devopsdays.org/events/2023-birmingham-al/welcome/",
     "startDate": "2023-04-20",
     "endDate": "2023-04-21",
     "city": "Birmingham, AL",


### PR DESCRIPTION
Changed line 307 to the correct url for DevOps Days Birmingham.