### PR TITLE
Fix to correct name of conference

### DIFF
--- a/conferences/2023/api.json
+++ b/conferences/2023/api.json
@@ -155,7 +155,7 @@
     "locales": "EN,FR"
   },
   {
-    "name": "Building Success in the API Ecosystem",
+    "name": "Platform Summit",
     "url": "https://nordicapis.com/events/platform-summit-2023",
     "startDate": "2023-10-16",
     "endDate": "2023-10-18",

--- a/conferences/2023/security.json
+++ b/conferences/2023/security.json
@@ -336,7 +336,7 @@
     "locales": "EN"
   },
   {
-    "name": "Platform Summit 2023",
+    "name": "Platform Summit",
     "url": "https://nordicapis.com/events/platform-summit-2023",
     "startDate": "2023-10-16",
     "endDate": "2023-10-18",

--- a/conferences/2023/security.json
+++ b/conferences/2023/security.json
@@ -336,7 +336,7 @@
     "locales": "EN"
   },
   {
-    "name": "Building Success in the API Ecosystem",
+    "name": "Platform Summit 2023",
     "url": "https://nordicapis.com/events/platform-summit-2023",
     "startDate": "2023-10-16",
     "endDate": "2023-10-18",


### PR DESCRIPTION
Fixing the conference name of Nordic APIs conference Platform Summit 2023. 
https://nordicapis.com/events/platform-summit-2023/

