### PR TITLE
Remove World Conf. on Data Science & Statistics

### DIFF
--- a/conferences/2023/data.json
+++ b/conferences/2023/data.json
@@ -315,19 +315,6 @@
     "locales": "EN"
   },
   {
-    "name": "World Conference on Data Science & Statistics",
-    "url": "https://datascience.thepeopleevents.com",
-    "startDate": "2023-06-26",
-    "endDate": "2023-06-28",
-    "city": "Frankfurt",
-    "country": "Germany",
-    "online": false,
-    "cfpUrl": "https://datascience.thepeopleevents.com/submit-abstract",
-    "cfpEndDate": "2023-04-25",
-    "locales": "EN",
-    "offersSignLanguageOrCC": true
-  },
-  {
     "name": "Databricks Data + AI Summit",
     "url": "https://www.databricks.com/dataaisummit",
     "startDate": "2023-06-26",


### PR DESCRIPTION
The event "World Conference on Data Science & Statistics" appears to be a fake event. This removes its entry from the JSON.

The website is a bit dodgy. It references last year's conference yet there is no evidence of this event on the internet. A search on archive.org of the website shows a strange history, with the contact information ranging from Uttar Pradesh to Northern Alabama. The certificate for the root domain is invalid and throws a security warning in most browsers.

Last, it appears that they are approving submitted talks and then requesting payment for the conference. This is unusual for accepted speakers.