### PR TITLE
Remove Devworld conference in 2023

### DIFF
--- a/conferences/2023/general.json
+++ b/conferences/2023/general.json
@@ -1308,20 +1308,6 @@
     "locales": "EN"
   },
   {
-    "name": "Devworld Conference",
-    "url": "https://devworldconference.com",
-    "startDate": "2023-09-28",
-    "endDate": "2023-09-29",
-    "city": "Amsterdam",
-    "country": "Netherlands",
-    "online": true,
-    "cfpUrl": "https://docs.google.com/forms/d/e/1FAIpQLSePbiKSSOLKQOJqG65ifQ0KtY1dsqPqA7N0pu9QY1bK1-ciDQ/viewform",
-    "cfpEndDate": "2023-06-30",
-    "twitter": "@devworld_conf",
-    "cocUrl": "https://devworldconference.com/code-of-conduct",
-    "locales": "EN"
-  },
-  {
     "name": "Paris Web",
     "url": "https://www.paris-web.fr",
     "startDate": "2023-09-28",

--- a/conferences/2023/java.json
+++ b/conferences/2023/java.json
@@ -400,20 +400,6 @@
     "locales": "EN"
   },
   {
-    "name": "Devworld Conference",
-    "url": "https://devworldconference.com",
-    "startDate": "2023-09-28",
-    "endDate": "2023-09-29",
-    "city": "Amsterdam",
-    "country": "Netherlands",
-    "online": true,
-    "cfpUrl": "https://docs.google.com/forms/d/e/1FAIpQLSePbiKSSOLKQOJqG65ifQ0KtY1dsqPqA7N0pu9QY1bK1-ciDQ/viewform",
-    "cfpEndDate": "2023-06-30",
-    "twitter": "@devworld_conf",
-    "cocUrl": "https://devworldconference.com/code-of-conduct",
-    "locales": "EN"
-  },
-  {
     "name": "Central Ohio Software Symposium",
     "url": "https://nofluffjuststuff.com/columbus",
     "startDate": "2023-09-29",

--- a/conferences/2023/javascript.json
+++ b/conferences/2023/javascript.json
@@ -957,20 +957,6 @@
     "cocUrl": "https://www.jsday.ie/code-of-conduct"
   },
   {
-    "name": "Devworld Conference",
-    "url": "https://devworldconference.com",
-    "startDate": "2023-09-28",
-    "endDate": "2023-09-29",
-    "city": "Amsterdam",
-    "country": "Netherlands",
-    "online": true,
-    "cfpUrl": "https://docs.google.com/forms/d/e/1FAIpQLSePbiKSSOLKQOJqG65ifQ0KtY1dsqPqA7N0pu9QY1bK1-ciDQ/viewform",
-    "cfpEndDate": "2023-06-30",
-    "twitter": "@devworld_conf",
-    "cocUrl": "https://devworldconference.com/code-of-conduct",
-    "locales": "EN"
-  },
-  {
     "name": "JSGameDev Summit",
     "url": "https://jsgamedev.com",
     "startDate": "2023-09-28",


### PR DESCRIPTION
Removing in favor of: https://github.com/tech-conferences/conference-data/pull/5665

Requested by email by the organizer