### PR TITLE
Add Mastodon For Java Forum Nord

### DIFF
--- a/conferences/2023/java.json
+++ b/conferences/2023/java.json
@@ -369,6 +369,7 @@
     "country": "Germany",
     "online": false,
     "twitter": "@JavaForumNord",
+    "mastdon": "https://ijug.social/@JavaForumNord",
     "cocUrl": "https://javaforumnord.de/2023/verhaltenscodex-code-of-conduct/",
     "locales": "DE,EN"
   },

--- a/conferences/2023/java.json
+++ b/conferences/2023/java.json
@@ -369,7 +369,7 @@
     "country": "Germany",
     "online": false,
     "twitter": "@JavaForumNord",
-    "mastdon": "https://ijug.social/@JavaForumNord",
+    "mastodon": "https://ijug.social/@JavaForumNord",
     "cocUrl": "https://javaforumnord.de/2023/verhaltenscodex-code-of-conduct/",
     "locales": "DE,EN"
   },


### PR DESCRIPTION
Mastodon was added with https://github.com/tech-conferences/confs.tech/pull/564.
Please have a look @hmasila, @nimzco und @cgrail. I am not sure if I did this correctly.