### PR TITLE
Fix Mastodon For Java Forum Nord

### DIFF
--- a/conferences/2023/java.json
+++ b/conferences/2023/java.json
@@ -369,7 +369,7 @@
     "country": "Germany",
     "online": false,
     "twitter": "@JavaForumNord",
-    "mastodon": "https://ijug.social/@JavaForumNord",
+    "mastodon": "@JavaForumNord@ijug.social",
     "cocUrl": "https://javaforumnord.de/2023/verhaltenscodex-code-of-conduct/",
     "locales": "DE,EN"
   },


### PR DESCRIPTION
              @FrittenLoverMarvin The format should be '@username@instance'

_Originally posted by @hmasila in https://github.com/tech-conferences/conference-data/issues/5705#issuecomment-1639108773_

This fixes the format.