### PR TITLE
Add RedwoodJS Conference for javascript

### DIFF
--- a/conferences/2023/javascript.json
+++ b/conferences/2023/javascript.json
@@ -991,6 +991,18 @@
     "cocUrl": "https://www.jsday.ie/code-of-conduct"
   },
   {
+    "name": "RedwoodJS Conference",
+    "url": "https://redwoodjsconf.com",
+    "startDate": "2023-09-26",
+    "endDate": "2023-09-29",
+    "city": "Grants Pass, OR",
+    "country": "U.S.A.",
+    "online": true,
+    "twitter": "@redwoodjs",
+    "cocUrl": "https://github.com/redwoodjs/redwood/blob/main/CODE_OF_CONDUCT.md",
+    "locales": "EN"
+  },
+  {
     "name": "JSGameDev Summit",
     "url": "https://jsgamedev.com",
     "startDate": "2023-09-28",

--- a/config/validLocations.js
+++ b/config/validLocations.js
@@ -631,6 +631,7 @@ module.exports = {
     "Fort Worth, TX",
     "Galveston, TX",
     "Grand Rapids, MI",
+    "Grants Pass, OR",
     "Grapevine, TX",
     "Half Moon Bay, CA",
     "Hartford, CT",


### PR DESCRIPTION
## Conference information
Website: https://redwoodjsconf.com/

Twitter: https://twitter.com/@redwoodjs

Github: @ahaywood

```
// javascript

{
  "name": "RedwoodJS Conference",
  "url": "https://redwoodjsconf.com",
  "startDate": "2023-09-26",
  "endDate": "2023-09-29",
  "city": "Grants Pass",
  "country": "U.S.A.",
  "online": true,
  "twitter": "@redwoodjs",
  "cocUrl": "https://github.com/redwoodjs/redwood/blob/main/CODE_OF_CONDUCT.md",
  "locales": "EN"
}
```