### PR TITLE
FestJS Conference reschedule

### DIFF
--- a/conferences/2023/javascript.json
+++ b/conferences/2023/javascript.json
@@ -1352,20 +1352,6 @@
     "locales": "EN"
   },
   {
-    "name": "Javascript Fest Krakow",
-    "url": "https://fest.dev/events/js/krakow-2023",
-    "startDate": "2023-11-25",
-    "endDate": "2023-11-25",
-    "city": "Kraków",
-    "country": "Poland",
-    "online": false,
-    "cfpUrl": "https://docs.google.com/forms/d/1OPrfCEnCh_PHYZnFmeh5ufXQvxzOr4IMs_O8ale4ovs/edit",
-    "cfpEndDate": "2023-09-01",
-    "twitter": "@devfestconf",
-    "cocUrl": "https://fest.dev/coc/",
-    "locales": "EN"
-  },
-  {
     "name": "TestJS Summit",
     "url": "https://testjssummit.com",
     "startDate": "2023-12-07",

--- a/conferences/2024/javascript.json
+++ b/conferences/2024/javascript.json
@@ -36,7 +36,7 @@
     "country": "Poland",
     "online": false,
     "cfpUrl": "https://docs.google.com/forms/d/1OPrfCEnCh_PHYZnFmeh5ufXQvxzOr4IMs_O8ale4ovs/edit",
-    "cfpEndDate": "2023-09-01",
+    "cfpEndDate": "2023-11-15",
     "twitter": "@devfestconf",
     "cocUrl": "https://fest.dev/coc/",
     "locales": "EN"

--- a/conferences/2024/javascript.json
+++ b/conferences/2024/javascript.json
@@ -28,6 +28,20 @@
     "locales": "EN"
   },
   {
+    "name": "FestJS Krakow",
+    "url": "https://fest.dev/events/js/krakow-2024/",
+    "startDate": "2024-03-22",
+    "endDate": "2024-03-22",
+    "city": "Kraków",
+    "country": "Poland",
+    "online": false,
+    "cfpUrl": "https://docs.google.com/forms/d/1OPrfCEnCh_PHYZnFmeh5ufXQvxzOr4IMs_O8ale4ovs/edit",
+    "cfpEndDate": "2023-09-01",
+    "twitter": "@devfestconf",
+    "cocUrl": "https://fest.dev/coc/",
+    "locales": "EN"
+  },
+  {
     "name": "enterJS",
     "url": "https://enterjs.de",
     "startDate": "2024-05-07",


### PR DESCRIPTION
Due to organisational reasons we were not able to organize an event in 2023 so we decide to reschedule it to 2024 so that why i'm sending you PR