### PR TITLE
Fix date for Next.js Conf

### DIFF
--- a/conferences/2023/javascript.json
+++ b/conferences/2023/javascript.json
@@ -1128,8 +1128,8 @@
   {
     "name": "Next.js Conf",
     "url": "https://nextjs.org/conf",
-    "startDate": "2023-10-10",
-    "endDate": "2023-10-10",
+    "startDate": "2023-10-26",
+    "endDate": "2023-10-26",
     "online": true,
     "cfpUrl": "https://vercel.fyi/cfp",
     "cfpEndDate": "2023-09-24",


### PR DESCRIPTION
[The website](https://nextjs.org/conf) now lists Oct. 26 as the date.