### PR TITLE
Small changes in conf dates (one in 2023, another in 2024)

### DIFF
--- a/conferences/2023/java.json
+++ b/conferences/2023/java.json
@@ -2,8 +2,8 @@
   {
     "name": "SpringOne Essentials",
     "url": "https://springone.io",
-    "startDate": "2023-01-25",
-    "endDate": "2023-01-27",
+    "startDate": "2023-01-24",
+    "endDate": "2023-01-26",
     "online": true,
     "twitter": "@springone",
     "locales": "EN"

--- a/conferences/2024/data.json
+++ b/conferences/2024/data.json
@@ -74,8 +74,8 @@
   {
     "name": "DataConnect Conference",
     "url": "https://www.dataconnectconf.com",
-    "startDate": "2024-07-25",
-    "endDate": "2024-07-26",
+    "startDate": "2024-07-11",
+    "endDate": "2024-07-12",
     "city": "Columbus, OH",
     "country": "U.S.A.",
     "online": true,


### PR DESCRIPTION
I used official websites for checking it:

2023: https://springone.io/essentials/schedule\#jan-24
2024: https://www.dataconnectconf.com/