### PR TITLE
Add Community over Code EU

### DIFF
--- a/conferences/2024/general.json
+++ b/conferences/2024/general.json
@@ -198,6 +198,19 @@
     "locales": "EN"
   },
   {
+    "name": "Community over Code EU",
+    "url": "https://eu.communityovercode.org/",
+    "startDate": "2024-06-03",
+    "endDate": "2024-06-05",
+    "city": "Bratislava",
+    "country": "Slovakia",
+    "online": false,
+    "cfpUrl": "https://sessionize.com/coceu-2024/",
+    "cfpEndDate": "2024-01-12",
+    "cocUrl": "https://eu.communityovercode.org/coc/",
+    "locales": "EN"
+  },
+  {
     "name": "RenderATL",
     "url": "https://RenderATL.com",
     "startDate": "2024-06-12",


### PR DESCRIPTION
Adds Community over Code EU (June 3-5), the former ApacheCon, to the general category.