### PR TITLE
Renamed "Open Code Experience" to "Open Community Experience"

### DIFF
--- a/conferences/2024/general.json
+++ b/conferences/2024/general.json
@@ -886,8 +886,8 @@
     "locales": "EN"
   },
   {
-    "name": "Open Code Experience",
-    "url": "https://www.opencode-x.org",
+    "name": "Open Community Experience",
+    "url": "https://www.ocxconf.org",
     "startDate": "2024-10-22",
     "endDate": "2024-10-24",
     "city": "Mainz",


### PR DESCRIPTION
The conference was renamed.