### PR TITLE
Add Pycon Colombia 2024

### DIFF
--- a/conferences/2024/python.json
+++ b/conferences/2024/python.json
@@ -209,5 +209,15 @@
     "cfpEndDate": "2024-06-15",
     "twitter": "@neo4j",
     "locales": "EN"
+  },
+  {
+    "name": "Pycon Colombia 2024",
+    "url": "https://2024.pycon.co/en",
+    "startDate": "2024-06-07",
+    "endDate": "2024-06-09",
+    "city": "Medellín",
+    "country": "Colombia",
+    "online": false,
+    "locales": "EN, ES"
   }
 ]

--- a/conferences/2024/python.json
+++ b/conferences/2024/python.json
@@ -211,7 +211,7 @@
     "locales": "EN"
   },
   {
-    "name": "Pycon Colombia 2024",
+    "name": "Pycon Colombia",
     "url": "https://2024.pycon.co/en",
     "startDate": "2024-06-07",
     "endDate": "2024-06-09",


### PR DESCRIPTION
fixes #6600

 [Pycon Colombia 2024](https://2024.pycon.co/en) From June 7 to 9 | Medellin Colombia

![image](https://github.com/tech-conferences/conference-data/assets/25883220/806352fa-9218-4368-874a-44a8dc92217c)

