### PR TITLE
Add Dev2Next 2024

### DIFF
--- a/conferences/2024/general.json
+++ b/conferences/2024/general.json
@@ -1100,8 +1100,8 @@
   {
     "name": "Dev2Next",
     "url": "https://www.dev2next.com/",
-    "startDate": "2024-10-30",
-    "endDate": "2024-11-03",
+    "startDate": "2024-09-30",
+    "endDate": "2024-10-03",
     "city": "Lone Tree, CO",
     "country": "U.S.A.",
     "online": false,

--- a/conferences/2024/general.json
+++ b/conferences/2024/general.json
@@ -1096,5 +1096,17 @@
     "cocUrl": "https://www.ittage.informatik-aktuell.de/konferenz/code-of-coduct.html",
     "locales": "DE,EN",
     "mastodon": "@informatikaktuell@det.social"
+  },
+  {
+    "name": "Dev2Next",
+    "url": "https://www.dev2next.com/",
+    "startDate": "2024-10-30",
+    "endDate": "2024-11-03",
+    "city": "Lone Tree, CO",
+    "country": "U.S.A.",
+    "online": false,
+    "twitter": "@dev2next",
+    "locales": "EN"
   }
+
 ]


### PR DESCRIPTION
[DEV2NEXT](https://dev.events/conferences/dev2-next-l6tuuyjq)
[Full-stack](https://dev.events/AM/fullstack) conference in [Lone Tree](https://dev.events/AM/US/CO/Lone_Tree/fullstack), [Colorado](https://dev.events/AM/US/CO/fullstack), [United States](https://dev.events/AM/US/fullstack)