### PR TITLE
reorder the conferences

### DIFF
--- a/conferences/2024/css.json
+++ b/conferences/2024/css.json
@@ -60,6 +60,17 @@
     "locales": "EN,DE"
   },
   {
+    "name": "CSSDAY",
+    "url": "https://cssday.nl/2024",
+    "startDate": "2024-06-06",
+    "endDate": "2024-06-07",
+    "city": "Amsterdam",
+    "country": "Netherlands",
+    "online": true,
+    "twitter": "@CSSDayConf",
+    "cocUrl": "https://cssday.nl/2024/contact#code-of-conduct"
+  },
+  {
     "name": "RenderATL",
     "url": "https://RenderATL.com",
     "startDate": "2024-06-12",
@@ -143,16 +154,5 @@
     "twitter": "@frontendbcn",
     "cocUrl": "https://frontend.barcelona/code-of-conduct",
     "locales": "EN"
-  },
-  {
-    "name": "CSSDAY",
-    "url": "https://cssday.nl/2024",
-    "startDate": "2024-06-06",
-    "endDate": "2024-06-07",
-    "city": "Amsterdam",
-    "country": "Netherlands",
-    "online": true,
-    "twitter": "@CSSDayConf",
-    "cocUrl": "https://cssday.nl/2024/contact#code-of-conduct"
   }
 ]

--- a/conferences/2024/data.json
+++ b/conferences/2024/data.json
@@ -677,6 +677,18 @@
     "locales": "EN"
   },
   {
+    "name": "8th Annual Toronto Machine Learning Summit (TMLS)",
+    "url": "https://www.torontomachinelearning.com/",
+    "startDate": "2024-07-10",
+    "endDate": "2024-07-14",
+    "city": "Toronto",
+    "country": "Canada",
+    "online": true,
+    "twitter": "@TMLS_TO",
+    "cocUrl": "https://www.torontomachinelearning.com/code-of-conduct/",
+    "locales": "EN"
+  },
+  {
     "name": "DataConnect Conference",
     "url": "https://www.dataconnectconf.com",
     "startDate": "2024-07-11",
@@ -1117,18 +1129,6 @@
     "cfpEndDate": "2024-11-18",
     "twitter": "@conf42com",
     "cocUrl": "https://www.conf42.com/code-of-conduct",
-    "locales": "EN"
-  },
-  {
-    "name": "8th Annual Toronto Machine Learning Summit (TMLS)",
-    "url": "https://www.torontomachinelearning.com/",
-    "startDate": "2024-07-10",
-    "endDate": "2024-07-14",
-    "city": "Toronto",
-    "country": "Canada",
-    "online": true,
-    "twitter": "@TMLS_TO",
-    "cocUrl": "https://www.torontomachinelearning.com/code-of-conduct/",
     "locales": "EN"
   }
 ]

--- a/conferences/2024/devops.json
+++ b/conferences/2024/devops.json
@@ -762,6 +762,17 @@
     "locales": "EN"
   },
   {
+    "name": "DevSecOps Melbourne",
+    "url": "https://devsecops-mel.coriniumintelligence.com/",
+    "startDate": "2024-07-17",
+    "endDate": "2024-07-17",
+    "city": "Melbourne",
+    "country": "Australia",
+    "online": false,
+    "twitter": "@CoriniumGlobal",
+    "locales": "EN"
+  },
+  {
     "name": "KCD Lima",
     "url": "https://community.cncf.io/events/details/cncf-kcd-lima-peru-presents-kcd-lima-peru-2024",
     "startDate": "2024-07-20",
@@ -1132,17 +1143,6 @@
     "cfpEndDate": "2024-11-04",
     "twitter": "@conf42com",
     "cocUrl": "https://www.conf42.com/code-of-conduct",
-    "locales": "EN"
-  },
-  {
-    "name": "DevSecOps Melbourne",
-    "url": "https://devsecops-mel.coriniumintelligence.com/",
-    "startDate": "2024-07-17",
-    "endDate": "2024-07-17",
-    "city": "Melbourne",
-    "country": "Australia",
-    "online": false,
-    "twitter": "@CoriniumGlobal",
     "locales": "EN"
   }
 ]

--- a/conferences/2024/general.json
+++ b/conferences/2024/general.json
@@ -1157,6 +1157,18 @@
     "locales": "EN"
   },
   {
+    "name": "Open Source Summit Japan",
+    "url": "https://events.linuxfoundation.org/open-source-summit-japan/",
+    "startDate": "2024-10-28",
+    "endDate": "2024-10-29",
+    "city": "Tokyo",
+    "country": "Japan",
+    "online": true,
+    "cfpUrl": "https://events.linuxfoundation.org/open-source-summit-japan/program/cfp",
+    "cocUrl": "https://events.linuxfoundation.org/open-source-summit-japan/program/cfp/#code-of-conduct",
+    "locales": "EN"
+  },
+  {
     "name": "SmashingConf Antwerp",
     "url": "https://smashingconf.com/antwerp-2024",
     "startDate": "2024-10-28",
@@ -1224,6 +1236,19 @@
     "mastodon": "@bdxio@bdx.town"
   },
   {
+    "name": "WasmCon",
+    "url": "https://events.linuxfoundation.org/wasmcon",
+    "startDate": "2024-11-11",
+    "endDate": "2024-11-12",
+    "city": "Salt Lake City, UT",
+    "country": "U.S.A.",
+    "online": false,
+    "cfpUrl": "https://events.linuxfoundation.org/wasmcon/program/cfp",
+    "twitter": "@linuxfoundation",
+    "cocUrl": "https://events.linuxfoundation.org/wasmcon/attend/code-of-conduct/",
+    "locales": "EN"
+  },
+  {
     "name": "DevFestYYC",
     "url": "https://devfestyyc.com",
     "startDate": "2024-11-15",
@@ -1262,30 +1287,5 @@
     "cocUrl": "https://www.ittage.informatik-aktuell.de/konferenz/code-of-coduct.html",
     "locales": "DE,EN",
     "mastodon": "@informatikaktuell@det.social"
-  },
-  {
-    "name": "Open Source Summit Japan",
-    "url": "https://events.linuxfoundation.org/open-source-summit-japan/",
-    "startDate": "2024-10-28",
-    "endDate": "2024-10-29",
-    "city": "Tokyo",
-    "country": "Japan",
-    "online": true,
-    "cfpUrl": "https://events.linuxfoundation.org/open-source-summit-japan/program/cfp",
-    "cocUrl": "https://events.linuxfoundation.org/open-source-summit-japan/program/cfp/#code-of-conduct",
-        "locales": "EN"
-  },
-  {  
-  "name": "WasmCon",
-    "url": "https://events.linuxfoundation.org/wasmcon",
-    "startDate": "2024-11-11",
-    "endDate": "2024-11-12",
-    "city": "Salt Lake City, UT",
-    "country": "U.S.A.",
-    "online": false,
-    "cfpUrl": "https://events.linuxfoundation.org/wasmcon/program/cfp",
-    "twitter": "@linuxfoundation",
-    "cocUrl": "https://events.linuxfoundation.org/wasmcon/attend/code-of-conduct/",
-    "locales": "EN"
   }
 ]

--- a/conferences/2024/performance.json
+++ b/conferences/2024/performance.json
@@ -139,6 +139,16 @@
     "locales": "DE"
   },
   {
+    "name": "performance.now()",
+    "url": "https://perfnow.nl",
+    "startDate": "2024-11-14",
+    "endDate": "2024-11-15",
+    "city": "Amsterdam",
+    "country": "Netherlands",
+    "online": true,
+    "twitter": "@perfnowconf"
+  },
+  {
     "name": "QCon",
     "url": "https://qconsf.com/medialisting2024",
     "startDate": "2024-11-18",
@@ -149,15 +159,5 @@
     "cocUrl": "https://qconferences.com/code-conduct",
     "locales": "EN",
     "mastodon": "@techhub.social@qcon"
-  },
-  {
-    "name": "performance.now()",
-    "url": "https://perfnow.nl",
-    "startDate": "2024-11-14",
-    "endDate": "2024-11-15",
-    "city": "Amsterdam",
-    "country": "Netherlands",
-    "online": true,
-    "twitter": "@perfnowconf"
   }
 ]

--- a/conferences/2024/security.json
+++ b/conferences/2024/security.json
@@ -256,6 +256,18 @@
     "locales": "EN"
   },
   {
+    "name": "CloudNativeSecurityCon",
+    "url": "https://events.linuxfoundation.org/cloudnativesecuritycon-north-america",
+    "startDate": "2024-06-26",
+    "endDate": "2024-06-27",
+    "city": "Seattle, WA",
+    "country": "U.S.A.",
+    "online": false,
+    "cfpUrl": "https://events.linuxfoundation.org/cloudnativesecuritycon-north-america/program/cfp",
+    "cocUrl": "https://events.linuxfoundation.org/about/code-of-conduct/",
+    "locales": "EN"
+  },
+  {
     "name": "WeAreDevelopers - World Congress",
     "url": "https://www.wearedevelopers.com/world-congress",
     "startDate": "2024-07-17",
@@ -467,18 +479,6 @@
     "online": false,
     "twitter": "@nofluff",
     "cocUrl": "https://archconf.com/home/code_of_conduct",
-    "locales": "EN"
-  },
-  {
-    "name": "CloudNativeSecurityCon",
-    "url": "https://events.linuxfoundation.org/cloudnativesecuritycon-north-america",
-    "startDate": "2024-06-26",
-    "endDate": "2024-06-27",
-    "city": "Seattle, WA",
-    "country": "U.S.A.",
-    "online": false,
-    "cfpUrl": "https://events.linuxfoundation.org/cloudnativesecuritycon-north-america/program/cfp",
-    "cocUrl": "https://events.linuxfoundation.org/about/code-of-conduct/",
     "locales": "EN"
   }
 ]

--- a/conferences/2025/devops.json
+++ b/conferences/2025/devops.json
@@ -1,17 +1,5 @@
 [
   {
-    "name": "JCON EUROPE",
-    "url": "https://jcon.one",
-    "startDate": "2025-05-19",
-    "endDate": "2025-05-22",
-    "city": "Cologne",
-    "country": "Germany",
-    "online": false,
-    "twitter": "@jcon_conference",
-    "cocUrl": "https://2024.europe.jcon.one/code-of-conduct",
-    "locales": "EN,DE"
-  },
-  {
     "name": "KubeCon + CloudNativeCon Europe",
     "url": "https://events.linuxfoundation.org/kubecon-cloudnativecon-europe-2025/",
     "startDate": "2025-04-01",
@@ -22,5 +10,17 @@
     "cfpUrl": "https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/program/cfp",
     "cocUrl": "https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/attend/code-of-conduct/",
     "locales": "EN"
+  },
+  {
+    "name": "JCON EUROPE",
+    "url": "https://jcon.one",
+    "startDate": "2025-05-19",
+    "endDate": "2025-05-22",
+    "city": "Cologne",
+    "country": "Germany",
+    "online": false,
+    "twitter": "@jcon_conference",
+    "cocUrl": "https://2024.europe.jcon.one/code-of-conduct",
+    "locales": "EN,DE"
   }
 ]

--- a/conferences/2025/dotnet.json
+++ b/conferences/2025/dotnet.json
@@ -1,12 +1,13 @@
 [
-{
-	"name": "Future Tech  NL",
-	"url": "https://futuretech.nl",
-	"startDate": "2025-03-13",
-	"endDate": "2025-03-13",
-	"online": false,
-	"city": "Utrecht",
-	"country": "Netherlands",
-	"twitter": "@futuretechnl",
-	"cocUrl": "https://futuretech.nl/code-of-conduct/"
-}]
+  {
+    "name": "Future Tech  NL",
+    "url": "https://futuretech.nl",
+    "startDate": "2025-03-13",
+    "endDate": "2025-03-13",
+    "city": "Utrecht",
+    "country": "Netherlands",
+    "online": false,
+    "twitter": "@futuretechnl",
+    "cocUrl": "https://futuretech.nl/code-of-conduct/"
+  }
+]

--- a/conferences/2026/devops.json
+++ b/conferences/2026/devops.json
@@ -1,14 +1,14 @@
 [
-	{
-	"name": "KubeCon + CloudNativeCon Europe",
-	"url": "https://events.linuxfoundation.org/kubecon-cloudnativecon-europe-2026/",
-	"startDate": "2026-03-23",
-	"endDate": "2026-03-26",
-	"city": "Amsterdam",
-	"country": "Netherlands",
-	"online": true,
-	"cfpUrl": "https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/program/cfp",
-	"cocUrl": "https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/attend/code-of-conduct/",
-	"locales": "EN"
-	}
+  {
+    "name": "KubeCon + CloudNativeCon Europe",
+    "url": "https://events.linuxfoundation.org/kubecon-cloudnativecon-europe-2026/",
+    "startDate": "2026-03-23",
+    "endDate": "2026-03-26",
+    "city": "Amsterdam",
+    "country": "Netherlands",
+    "online": true,
+    "cfpUrl": "https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/program/cfp",
+    "cocUrl": "https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/attend/code-of-conduct/",
+    "locales": "EN"
+  }
 ]


### PR DESCRIPTION
Thanks for creating a new Pull Request for this repository.

To get the conferce as fast as possible into confs.tech please consider the following things.

## Checklist for your change
- [ ] does not delete another conference
- [x] has passed the tests via `npm run test`
- [x] has the correct order via `npm run reorder-confs`
- [ ] is a developer conference: more than 3-4 people from different companies
- [ ] is not a webinar, hackathon, marketing, zoom meeting with one person
- [ ] URLs are reachable, as short as possible, do not contain tracking parameters and the website is dedicated for this event
- [ ] topic is correct
- [ ] conference name is as short as possible and does not include location and date
