### PR TITLE
Add kubeday Australia

### DIFF
--- a/conferences/2024/devops.json
+++ b/conferences/2024/devops.json
@@ -1005,6 +1005,20 @@
     "locales": "EN"
   },
   {
+    "name": "KubeDay Australia",
+    "url": "https://events.linuxfoundation.org/kubeday-australia/",
+    "startDate": "2024-10-15",
+    "endDate": "2024-10-15",
+    "city": "Melbourne",
+    "country": "Australia",
+    "online": false,
+    "cfpUrl": "https://events.linuxfoundation.org/kubeday-australia/program/cfp/",
+    "cfpEndDate": "2024-06-28",
+    "twitter": "@KubeCon_",
+    "cocUrl": "https://events.linuxfoundation.org/kubeday-australia/attend/code-of-conduct/",
+    "locales": "EN"
+  },
+  {
     "name": "Innovate Virginia",
     "url": "https://innovatevirginia.com",
     "startDate": "2024-10-25",
@@ -1041,6 +1055,20 @@
     "cfpEndDate": "2024-06-01",
     "twitter": "@Heapconf",
     "cocUrl": "https://heapcon.io/2024/code-of-conduct",
+    "locales": "EN"
+  },
+  {
+    "name": "KubeCon + CloudNativeCon North America",
+    "url": "https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america",
+    "startDate": "2024-11-12",
+    "endDate": "2024-11-15",
+    "city": "Salt Lake City, UT",
+    "country": "U.S.A.",
+    "online": false,
+    "cfpUrl": "https://sessionize.com/kubecon-cloudnativecon-north-america-2024",
+    "cfpEndDate": "2024-06-09",
+    "twitter": "@CloudNativeFdn",
+    "cocUrl": "https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/attend/code-of-conduct/",
     "locales": "EN"
   },
   {
@@ -1143,20 +1171,6 @@
     "cfpEndDate": "2024-11-04",
     "twitter": "@conf42com",
     "cocUrl": "https://www.conf42.com/code-of-conduct",
-    "locales": "EN"
-  },
-  {
-    "name": "KubeCon + CloudNativeCon North America",
-    "url": "https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america",
-    "startDate": "2024-11-12",
-    "endDate": "2024-11-15",
-    "city": "Salt Lake City, UT",
-    "country": "U.S.A.",
-    "online": false,
-    "cfpUrl": "https://sessionize.com/kubecon-cloudnativecon-north-america-2024",
-    "cfpEndDate": "2024-06-09",
-    "twitter": "@CloudNativeFdn",
-    "cocUrl": "https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/attend/code-of-conduct/",
     "locales": "EN"
   }
 ]

--- a/conferences/2024/general.json
+++ b/conferences/2024/general.json
@@ -539,6 +539,17 @@
     "locales": "EN"
   },
   {
+    "name": "Xen Project Summit/",
+    "url": "https://events.linuxfoundation.org/xen-project-summit/",
+    "startDate": "2024-06-04",
+    "endDate": "2024-06-06",
+    "city": "Lisbon",
+    "country": "Portugal",
+    "online": false,
+    "twitter": "@xen_org",
+    "locales": "EN"
+  },
+  {
     "name": "Frontend Nation",
     "url": "https://frontendnation.com",
     "startDate": "2024-06-04",
@@ -1287,16 +1298,5 @@
     "cocUrl": "https://www.ittage.informatik-aktuell.de/konferenz/code-of-coduct.html",
     "locales": "DE,EN",
     "mastodon": "@informatikaktuell@det.social"
-  },
-  {
-    "name": "Xen Project Summit/",
-    "url": "https://events.linuxfoundation.org/xen-project-summit/",
-    "startDate": "2024-06-04",
-    "endDate": "2024-06-06",
-    "city": "Lisbon",
-    "country": "Portugal",
-    "online": false,
-    "twitter": "@xen_org",
-    "locales": "EN"
   }
 ]

--- a/conferences/2026/devops.json
+++ b/conferences/2026/devops.json
@@ -11,17 +11,17 @@
     "cocUrl": "https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/attend/code-of-conduct/",
     "locales": "EN"
   },
-	{
-	"name": "KubeCon + CloudNativeCon North America",
-	"url": "https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america-2026/",
-	"startDate": "2026-10-26",
-	"endDate": "2026-10-29",
-	"city": "Los Angeles, CA",
-	"country": "U.S.A.",
-	"online": false,
-	"cfpUrl": "https://sessionize.com/kubecon-cloudnativecon-north-america-2026",
-	"twitter": "@CloudNativeFdn",
-	"cocUrl": "https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/attend/code-of-conduct/",
-	"locales": "EN"
-	}
+  {
+    "name": "KubeCon + CloudNativeCon North America",
+    "url": "https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america-2026/",
+    "startDate": "2026-10-26",
+    "endDate": "2026-10-29",
+    "city": "Los Angeles, CA",
+    "country": "U.S.A.",
+    "online": false,
+    "cfpUrl": "https://sessionize.com/kubecon-cloudnativecon-north-america-2026",
+    "twitter": "@CloudNativeFdn",
+    "cocUrl": "https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/attend/code-of-conduct/",
+    "locales": "EN"
+  }
 ]


### PR DESCRIPTION
fixes #6780

Thanks for creating a new Pull Request for this repository.

To get the conferce as fast as possible into confs.tech please consider the following things.

## Checklist for your change
- [x] does not delete another conference
- [x] has passed the tests via `npm run test`
- [x] has the correct order via `npm run reorder-confs`
- [x] is a developer conference: more than 3-4 people from different companies
- [x] is not a webinar, hackathon, marketing, zoom meeting with one person
- [x] URLs are reachable, as short as possible, do not contain tracking parameters and the website is dedicated for this event
- [x] topic is correct
- [x] conference name is as short as possible and does not include location and date
