### PR TITLE
Add akademy 2024 #6858

### DIFF
--- a/conferences/2024/general.json
+++ b/conferences/2024/general.json
@@ -955,6 +955,20 @@
     "locales": "EN"
   },
   {
+    "name": "Akademy",
+    "url": "https://akademy.kde.org/2024/",
+    "startDate": "2024-09-07",
+    "endDate": "2024-09-12",
+    "city": "Wuerzburg",
+    "country": "Germany",
+    "cfpUrl": "https://akademy.kde.org/2024/cfp/",
+    "cfpEndDate": "2024-05-31",
+    "twitter": "@akademy",
+    "cocUrl": "https://kde.org/code-of-conduct/",
+    "locales": "EN",
+    "mastodon": "@akademy@floss.social"
+  },
+  {
     "name": "Gartner Application Innovation & Business Solutions Summit",
     "url": "https://www.gartner.com/en/conferences/emea/applications-uk",
     "startDate": "2024-09-09",
@@ -1483,19 +1497,5 @@
     "cocUrl": "https://www.ittage.informatik-aktuell.de/konferenz/code-of-coduct.html",
     "locales": "DE,EN",
     "mastodon": "@informatikaktuell@det.social"
-  },
-  {
-    "name": "Akademy",
-    "url": "https://akademy.kde.org/2024/",
-    "startDate": "2024-09-07",
-    "endDate": "2024-09-12",
-    "city": "Wuerzburg",
-    "country": "Germany",
-    "cfpUrl": "https://akademy.kde.org/2024/cfp/",
-    "cfpEndDate": "2024-05-31",
-    "twitter": "@akademy",
-    "mastodon": "@akademy@floss.social",
-    "cocUrl": "https://kde.org/code-of-conduct/",
-    "locales": "EN"
-}
+  }
 ]

--- a/conferences/2024/general.json
+++ b/conferences/2024/general.json
@@ -1483,5 +1483,19 @@
     "cocUrl": "https://www.ittage.informatik-aktuell.de/konferenz/code-of-coduct.html",
     "locales": "DE,EN",
     "mastodon": "@informatikaktuell@det.social"
-  }
+  },
+  {
+    "name": "Akademy",
+    "url": "https://akademy.kde.org/2024/",
+    "startDate": "2024-09-07",
+    "endDate": "2024-09-12",
+    "city": "Wuerzburg",
+    "country": "Germany",
+    "cfpUrl": "https://akademy.kde.org/2024/cfp/",
+    "cfpEndDate": "2024-05-31",
+    "twitter": "@akademy",
+    "mastodon": "@akademy@floss.social",
+    "cocUrl": "https://kde.org/code-of-conduct/",
+    "locales": "EN"
+}
 ]


### PR DESCRIPTION
Fixes #6858 

I have added the conference to general.json, but I'm not sure if there is another suitable topic. Is this ok?
@JuanPabloDiaz 

## Checklist for your change
- [x] does not delete another conference
- [x] has passed the tests via `npm run test`
- [x] has the correct order via `npm run reorder-confs`
- [x] is a developer conference: more than 3-4 people from different companies
- [x] is not a webinar, hackathon, marketing, zoom meeting with one person
- [x] URLs are reachable, as short as possible, do not contain tracking parameters and the website is dedicated for this event
- [x] topic is correct
- [x] conference name is as short as possible and does not include location and date
