### PR TITLE
Test order of conferences

### DIFF
--- a/scripts/reorderConferencesByDate.js
+++ b/scripts/reorderConferencesByDate.js
@@ -1,14 +1,11 @@
 // Reorder a file by running (from the scripts folder)
 const fs = require('fs');
-const sortBy = require('lodash/sortBy');
-const parse = require('date-fns/parse');
 const conferenceReader = require('./utils/conferenceReader');
+const orderConferences = require('./utils/orderConferences');
 
 const BASE_DIR = 'conferences';
 
-const conferencesJSON = conferenceReader();
-
-const propertyOrder = require('../config/validFields');
+const conferencesJSON = conferenceReader(true);
 
 Object.keys(conferencesJSON).forEach(year => {
     Object.keys(conferencesJSON[year]).forEach(topic => {
@@ -18,21 +15,7 @@ Object.keys(conferencesJSON).forEach(year => {
         if (!Array.isArray(conferences)) {
             return;
         }
-        const sortedConfs = sortBy(conferences, [
-            conf => parse(conf.startDate, 'yyyy-MM-dd', new Date()).getTime(),
-            conf => parse(conf.endDate || conf.startDate, 'yyyy-MM-dd', new Date()).getTime(),
-            'name'
-        ]);
-
-        const sortedConfByProperties = sortedConfs.map(conference => {
-            const sortedEntry = {};
-            propertyOrder.forEach(property => {
-                sortedEntry[property] = conference[property];
-            });
-            return sortedEntry;
-        });
-
-        fs.writeFile(fileName, JSON.stringify(sortedConfByProperties, null, 2), () => {
+        fs.writeFile(fileName, orderConferences(conferences), () => {
             console.log(`File ${fileName} was successfully reordered`);
         });
     });

--- a/scripts/utils/conferenceReader.js
+++ b/scripts/utils/conferenceReader.js
@@ -1,10 +1,11 @@
 const fs = require('fs');
 const assert = require('assert');
 const topics = require('../../config/topics');
+const orderConferences = require('./orderConferences');
 
 const jsonFileRegex = /(.*).json$/;
 
-module.exports = function conferenceReader() {
+module.exports = function conferenceReader(reorderConferences) {
     const conferencesJSON = {};
 
     fs.readdirSync('conferences').forEach(year => {
@@ -18,11 +19,17 @@ module.exports = function conferenceReader() {
             if (fileContent.toString() === '[]') {
                 return;
             }
+            let conferences;
             try {
-                conferencesJSON[year][topic] = JSON.parse(fileContent);
+                conferences = JSON.parse(fileContent);
             } catch (exception) {
                 assert.fail(`Unable to read file: "${filePath}". Error: ${exception}`);
             }
+            const orderedConferences = orderConferences(conferences);
+            if (!reorderConferences && fileContent != orderedConferences) {
+                assert.fail(`Conferences not in the right order: "${filePath}". Please run 'npm run reorder-confs'`);
+            }
+            conferencesJSON[year][topic] = conferences;
         });
     });
 

--- a/scripts/utils/orderConferences.js
+++ b/scripts/utils/orderConferences.js
@@ -1,0 +1,24 @@
+const sortBy = require('lodash/sortBy');
+const parse = require('date-fns/parse');
+const propertyOrder = require('../../config/validFields');
+
+module.exports = function orderConferences(conferences) {
+    if (!Array.isArray(conferences)) {
+        return;
+    }
+    const sortedConfs = sortBy(conferences, [
+        conf => parse(conf.startDate, 'yyyy-MM-dd', new Date()).getTime(),
+        conf => parse(conf.endDate || conf.startDate, 'yyyy-MM-dd', new Date()).getTime(),
+        'name'
+    ]);
+
+    const sortedConfByProperties = sortedConfs.map(conference => {
+        const sortedEntry = {};
+        propertyOrder.forEach(property => {
+            sortedEntry[property] = conference[property];
+        });
+        return sortedEntry;
+    });
+
+    return JSON.stringify(sortedConfByProperties, null, 2);
+}

--- a/scripts/utils/orderConferences.js
+++ b/scripts/utils/orderConferences.js
@@ -21,4 +21,4 @@ module.exports = function orderConferences(conferences) {
     });
 
     return JSON.stringify(sortedConfByProperties, null, 2);
-}
+};


### PR DESCRIPTION
Thanks for creating a new Pull Request for this repository.

To get the conferce as fast as possible into confs.tech please consider the following things.

## Checklist for your change
- [ ] does not delete another conference
- [ ] has passed the tests via `npm run test`
- [ ] has the correct order via `npm run reorder-confs`
- [ ] is a developer conference: more than 3-4 people from different companies
- [ ] is not a webinar, hackathon, marketing, zoom meeting with one person
- [ ] URLs are reachable, as short as possible, do not contain tracking parameters and the website is dedicated for this event
- [ ] topic is correct
- [ ] conference name is as short as possible and does not include location and date
