### PR TITLE
Links nimzco test

### DIFF
--- a/.github/workflows/check_links.yaml
+++ b/.github/workflows/check_links.yaml
@@ -1,0 +1,59 @@
+name: Check links
+
+on:
+    pull_request:
+        branches: [main]
+    workflow_dispatch:
+    schedule:
+        - cron: '16 2 * * 6'
+
+jobs:
+    validate:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            issues: write
+        env:
+            issue-lookup-label: automated-link-issue
+            issue-content: ./lychee-out.md
+        steps:
+            - uses: actions/checkout@v4
+            - name: Restore lychee cache
+              uses: actions/cache@v4
+              with:
+                  path: .lycheecache
+                  key: cache-lychee-${{ github.sha }}
+                  restore-keys: cache-lychee-
+            - name: Link Checker
+              id: lychee
+              uses: lycheeverse/lychee-action@v1.10.0
+              with:
+                  fail: true
+                  args: --verbose --no-progress './conferences/2024/**/*.json' './conferences/2025/**/*.json' './conferences/2026/**/*.json' --exclude-mail
+                  output: ${{ env.issue-content }}
+
+            # Permissions (issues: read)
+            - name: 'Look for an existing issue'
+              if: ${{ failure() }}
+              id: last-issue
+              uses: micalevisk/last-issue-action@v2
+              # Find the last updated open issue with a `automated-issue` label:
+              with:
+                  state: open
+                  labels: ${{ env.issue-lookup-label }}
+
+            # Permissions (issues: write)
+            - name: 'Create a new issue, or update an existing one'
+              if: ${{ failure() }}
+              uses: peter-evans/create-issue-from-file@v4
+              with:
+                  title: 'docs: Broken links found'
+                  content-filepath: ${{ env.issue-content }}
+                  # Update an existing issue if one was found (issue_number),
+                  # otherwise an empty value creates a new issue:
+                  issue-number: ${{ steps['last-issue']['outputs']['issue-number'] }}
+                  # Add a label(s) that `last-issue` can use to find this issue,
+                  # and any other relevant labels for the issue itself:
+                  labels: |
+                      ${{ env.issue-lookup-label }}
+                      broken-link, docs

--- a/.github/workflows/check_links.yaml
+++ b/.github/workflows/check_links.yaml
@@ -29,7 +29,7 @@ jobs:
               uses: lycheeverse/lychee-action@v1.10.0
               with:
                   fail: true
-                  args: --verbose --no-progress './conferences/2024/**/*.json' './conferences/2025/**/*.json' './conferences/2026/**/*.json' --exclude-mail
+                  args: --verbose --no-progress --exclude-mail | grep url ./conferences/2024/**/*.json
                   output: ${{ env.issue-content }}
 
             # Permissions (issues: read)

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,10 @@
+<!-- This is a list of URLs that check_links workflow should ignore. -->
+
+/call-for-papers
+/codeOfConduct
+/code-of-conduct
+/cfp
+/coc
+https://www.gartner.com/en/conferences/emea/digital-workplace-uk
+https://www.gartner.com/en/conferences/na/symposium-us
+https://datascience.thepeopleevents.com


### PR DESCRIPTION
From https://github.com/tech-conferences/conference-data/actions/runs/9929145100/job/27426327077?pr=7022
Test with ` grep url ./conferences/2024/**/*.json` instead of the whole file