### PR TITLE
Remove We Love JS events - fake events

### DIFF
--- a/conferences/2023/javascript.json
+++ b/conferences/2023/javascript.json
@@ -873,18 +873,6 @@
     "twitter": "@utjs"
   },
   {
-    "name": "We Love JS",
-    "url": "https://welovejs.vercel.app",
-    "startDate": "2023-09-15",
-    "endDate": "2023-09-16",
-    "city": "Amsterdam",
-    "country": "Netherlands",
-    "online": false,
-    "locales": "EN",
-    "cfpUrl": "https://forms.gle/WYcDZcRW6gsy6qHj9",
-    "cfpEndDate": "2023-08-31"
-  },
-  {
     "name": "WeAreDevelopers Angular Day",
     "url": "https://www.wearedevelopers.com/event/angular-day-september-2023",
     "startDate": "2023-09-20",

--- a/conferences/2024/javascript.json
+++ b/conferences/2024/javascript.json
@@ -619,16 +619,6 @@
     "twitter": "@websummercamp"
   },
   {
-    "name": "We Love JS London",
-    "url": "https://welovejs.vercel.app/london",
-    "startDate": "2024-07-12",
-    "endDate": "2024-07-13",
-    "city": "London",
-    "country": "U.K.",
-    "online": false,
-    "locales": "EN"
-  },
-  {
     "name": "Middlesbrough Front End Conference",
     "url": "https://middlesbroughfe.co.uk",
     "startDate": "2024-07-17",
@@ -676,18 +666,6 @@
     "online": false,
     "locales": "EN",
     "twitter": "@cityjsconf"
-  },
-  {
-    "name": "We Love JS",
-    "url": "https://welovejs.vercel.app",
-    "startDate": "2024-08-09",
-    "endDate": "2024-08-10",
-    "city": "Amsterdam",
-    "country": "Netherlands",
-    "online": false,
-    "locales": "EN",
-    "cfpUrl": "https://forms.gle/WYcDZcRW6gsy6qHj9",
-    "cfpEndDate": "2024-06-30"
   },
   {
     "name": "React Rally",


### PR DESCRIPTION
A supposed speaker for one of these events reported on Twitter that they were NOT speaking. The website has been disabled by Vercel. The entries should probably be removed, and if it can be investigated, look for other events reported by the same user.

https://x.com/filrakowski/status/1811389689024160171

<img width="591" alt="screenshot of tweet linked above" src="https://github.com/user-attachments/assets/52d3140e-449f-44ea-9707-78d27b62114f">

I looked for other events hosted as a subdomain of `vercel.app`. I found these. The "let-us-go-2022" appears to be a valid event that already happened and has videos on YouTube. The chatgpt-conf event is suspect, no speakers announced, and suppposedly organized by ChatGPT. The sfai event goes to a 404. I won't try to remove any on this PR but FYI!

<img width="421" alt="Screenshot of three search results found for vercel.app" src="https://github.com/user-attachments/assets/4c20c752-a2d4-4e0e-91bd-8a458f569793">

## Checklist for your change
- [ ] does not delete another conference
- [ ] has passed the tests via `npm run test`
- [ ] has the correct order via `npm run reorder-confs`
- [ ] is a developer conference: more than 3-4 people from different companies
- [ ] is not a webinar, hackathon, marketing, zoom meeting with one person
- [ ] URLs are reachable, as short as possible, do not contain tracking parameters and the website is dedicated for this event
- [ ] topic is correct
- [ ] conference name is as short as possible and does not include location and date
