### PR TITLE
Log duplicate previous PR only if it makes sense

### DIFF
--- a/scripts/utils/logTestResult.ts
+++ b/scripts/utils/logTestResult.ts
@@ -84,7 +84,8 @@ export default async function logTestResult(testResult: TestResult) {
         logDuplicateFileName(duplicateError.conference);
         logDuplicateFileName(duplicateError.duplicate);
         logDifferences(duplicateError.conference, duplicateError.duplicate);
-        if (token) {
+        const duplicateWithPotentialPreviousPr = duplicateError.type === DuplicateType.Duplicate || duplicateError.type === DuplicateType.AlmostIdentical;
+        if (token && duplicateWithPotentialPreviousPr) {
             const prUrl = await getDuplicatePr(token, duplicateError);
             if (prUrl) {
                 duplicateErrorMessages.push(`  Potential Duplicate PR: ${prUrl}`);


### PR DESCRIPTION
A potential previos PR was searched and logged event it makes no sense. For example for conferences which are in general and other topics. This fix limits the logging of potential PRs to cases where it might make more sense.