### PR TITLE
Only execute link checker on schedule not for every PR

### DIFF
--- a/.github/workflows/check_links.yaml
+++ b/.github/workflows/check_links.yaml
@@ -1,9 +1,6 @@
 name: Check links
 
 on:
-    pull_request:
-        branches: [main]
-    workflow_dispatch:
     schedule:
         - cron: '16 2 * * 6'
 


### PR DESCRIPTION
As the link checker doesn't really work that well, we will just run it on schedule
