### PR TITLE
Add identity conferences for 2025

### DIFF
--- a/conferences/2025/identity.json
+++ b/conferences/2025/identity.json
@@ -1,0 +1,36 @@
+[
+  {
+    "name": "DICE Ecosystems",
+    "url": "https://lu.ma/DICEecosystems",
+    "startDate": "2025-03-04",
+    "endDate": "2025-03-05",
+    "city": "Zurich",
+    "country": "Switzerland",
+    "online": false,
+    "locales": "DE,EN",
+    "twitter": "@IdentityWoman"
+  },
+  {
+    "name": "IIW Internet Identity Workshop",
+    "url": "https://internetidentityworkshop.com",
+    "startDate": "2025-04-08",
+    "endDate": "2025-04-10",
+    "city": "Mountain View, CA",
+    "country": "U.S.A.",
+    "online": false,
+    "locales": "EN",
+    "cocUrl": "https://internetidentityworkshop.com/engagement-guidelines",
+    "twitter": "@idworkshop"
+  },
+  {
+    "name": "DICE Digital Identity unConference Europe",
+    "url": "https://lu.ma/DICE2025",
+    "startDate": "2025-09-02",
+    "endDate": "2025-09-04",
+    "city": "Zurich",
+    "country": "Switzerland",
+    "online": false,
+    "locales": "DE,EN",
+    "twitter": "@IdentityWoman"
+  }
+]


### PR DESCRIPTION
Thanks for creating a new Pull Request for this repository.

To get the conferce as fast as possible into confs.tech please consider the following things.

## Checklist for your change
- [x] does not delete another conference
- [x] has passed the tests via `npm run test`
- [x] has the correct order via `npm run reorder-confs`
- [x] is a developer conference: more than 3-4 people from different companies
- [x] is not a webinar, hackathon, marketing, zoom meeting with one person
- [x] URLs are reachable, as short as possible, do not contain tracking parameters and the website is dedicated for this event
- [x] topic is correct
- [x] conference name is as short as possible and does not include location and date
