### PR TITLE
Change NZ Tech Rally 2024 dates to 2025

### DIFF
--- a/conferences/2024/general.json
+++ b/conferences/2024/general.json
@@ -1509,21 +1509,6 @@
     "twitter": "@fnconf"
   },
   {
-    "name": "NZ Tech Rally",
-    "url": "https://nztechrally.nz",
-    "startDate": "2024-11-22",
-    "endDate": "2024-11-22",
-    "city": "Wellington",
-    "country": "New Zealand",
-    "online": false,
-    "locales": "EN",
-    "offersSignLanguageOrCC": true,
-    "cocUrl": "https://nztechrally.nz/code-of-conduct",
-    "cfpUrl": "https://nztechrally.nz/call-for-proposals",
-    "cfpEndDate": "2024-06-27",
-    "twitter": "@NZTechRally"
-  },
-  {
     "name": "Open Conf",
     "url": "https://www.open-conf.gr",
     "startDate": "2024-11-22",

--- a/conferences/2025/general.json
+++ b/conferences/2025/general.json
@@ -211,6 +211,21 @@
     "twitter": "@teqnationconf"
   },
   {
+    "name": "NZ Tech Rally",
+    "url": "https://nztechrally.nz",
+    "startDate": "2025-05-16",
+    "endDate": "2025-05-16",
+    "city": "Wellington",
+    "country": "New Zealand",
+    "online": false,
+    "locales": "EN",
+    "offersSignLanguageOrCC": true,
+    "cocUrl": "https://nztechrally.nz/code-of-conduct",
+    "cfpUrl": "https://nztechrally.nz/call-for-proposals",
+    "cfpEndDate": "2024-06-27",
+    "twitter": "@NZTechRally"
+  },
+  {
     "name": "Future Frontend",
     "url": "https://futurefrontend.com",
     "startDate": "2025-05-27",


### PR DESCRIPTION
Event moved from 22nd November 2024 to 16th May 2025.

Thanks for creating a new Pull Request for this repository.

To get the conference as fast as possible into confs.tech please consider the following things.

## Checklist for your change
- [x] does not delete another conference
- [x] has passed the tests via `npm run test`
- [x] has the correct order via `npm run reorder-confs`
- [x] is a developer conference: more than 3-4 people from different companies
- [x] is not a webinar, hackathon, marketing, zoom meeting with one person
- [x] URLs are reachable, as short as possible, do not contain tracking parameters and the website is dedicated for this event
- [x] topic is correct
- [x] conference name is as short as possible and does not include location and date
