### PR TITLE
added peredelanoconf to 2025/networking.json

### DIFF
--- a/conferences/2025/data.json
+++ b/conferences/2025/data.json
@@ -74,6 +74,15 @@
     "offersSignLanguageOrCC": true
   },
   {
+    "name": "ICMLT",
+    "url": "https://www.icmlt.org/",
+    "startDate": "2025-05-23",
+    "endDate": "2025-05-25",
+    "city": "Helsinki",
+    "country": "Finland",
+    "locales": "EN"
+  },
+  {
     "name": "MLCon",
     "url": "https://mlconference.ai/munich",
     "startDate": "2025-05-23",

--- a/conferences/2025/networking.json
+++ b/conferences/2025/networking.json
@@ -1,5 +1,15 @@
 [
   {
+    "name": "Peredelanoconf Berlin",
+    "url": "https://peredelanoconf.com/berlin",
+    "startDate": "2025-01-25",
+    "endDate": "2025-01-25",
+    "city": "Berlin",
+    "country": "Germany",
+    "twitter": "@peredelano_conf",
+    "locales": "RU,UA,BY"
+  },
+  {
     "name": "Unhacked International CyberSecurity",
     "url": "https://momentera.org/conferences/unhacked-conference",
     "startDate": "2025-02-10",


### PR DESCRIPTION
Thanks for creating a new Pull Request for this repository.

To get the conferce as fast as possible into confs.tech please consider the following things.

## Checklist for your change
- [x] does not delete another conference
- [x] has passed the tests via `npm run test`
- [] has the correct order via `npm run reorder-confs`
- [x] is a developer conference: more than 3-4 people from different companies
- [x] is not a webinar, hackathon, marketing, zoom meeting with one person
- [x] URLs are reachable, as short as possible, do not contain tracking parameters and the website is dedicated for this event
- [x] topic is correct
- [ ] conference name is as short as possible and does not include location and date
