### PR TITLE
added some around-ML conferences in 2024/data.json and 2025/data.json

### DIFF
--- a/conferences/2024/data.json
+++ b/conferences/2024/data.json
@@ -1287,6 +1287,15 @@
     "twitter": "@OMHconf"
   },
   {
+    "name": "ML and AI Model Development and Governance",
+    "url": "https://www.marcusevans.com/conferences/aifinance",
+    "startDate": "2024-11-27",
+    "endDate": "2024-11-28",
+    "city": "Amsterdam",
+    "country": "Netherlands",
+    "locales": "EN"
+  },
+  {
     "name": "Tech Leader Summit",
     "url": "https://techleadersummit.io",
     "startDate": "2024-12-04",

--- a/conferences/2025/data.json
+++ b/conferences/2025/data.json
@@ -74,6 +74,24 @@
     "offersSignLanguageOrCC": true
   },
   {
+    "name": "Data Science Next Conference",
+    "url": "https://dscnextcon.com/",
+    "startDate": "2025-05-07",
+    "endDate": "2025-05-09",
+    "city": "Amsterdam",
+    "country": "Netherlands",
+    "locales": "EN"
+  },
+  {
+    "name": "AI & Machine Learning Summit",
+    "url": "https://www.dbta.com/DataSummit/2025/AIMachineLearningSummit.aspx",
+    "startDate": "2025-05-14",
+    "endDate": "2025-05-15",
+    "city": "Boston, MA",
+    "country": "U.S.A.",
+    "locales": "EN"
+  },
+  {
     "name": "ICMLT",
     "url": "https://www.icmlt.org/",
     "startDate": "2025-05-23",


### PR DESCRIPTION
Thanks for creating a new Pull Request for this repository.

To get the conferce as fast as possible into confs.tech please consider the following things.

## Checklist for your change
- [x] does not delete another conference
- [x] has passed the tests via `npm run test`
- [x] has the correct order via `npm run reorder-confs`
- [x] is a developer conference: more than 3-4 people from different companies
- [x] is not a webinar, hackathon, marketing, zoom meeting with one person
- [x] URLs are reachable, as short as possible, do not contain tracking parameters and the website is dedicated for this event
- [x] topic is correct
- [x] conference name is as short as possible and does not include location and date
