### PR TITLE
added Voxxed Days CERN to 2025/general.json; added Oredev to 2024/general.json; added J-Fall to 2024/java.json

### DIFF
--- a/conferences/2024/general.json
+++ b/conferences/2024/general.json
@@ -1346,17 +1346,6 @@
     "twitter": "@PASSDataSummit"
   },
   {
-    "name": "Oredev",
-    "url": "https://oredev.org/",
-    "startDate": "2024-11-06",
-    "endDate": "2024-11-08",
-    "city": "Malmö",
-    "country": "Sweden",
-    "online": false,
-    "locales": "EN",
-    "twitter": "@oredev"
-  },
-  {
     "name": "TURING x SYSTM Growth Summit",
     "url": "https://turingfest.com/turingxsystm",
     "startDate": "2024-11-06",
@@ -1366,6 +1355,17 @@
     "online": false,
     "locales": "EN",
     "twitter": "@turingfest"
+  },
+  {
+    "name": "Oredev",
+    "url": "https://oredev.org/",
+    "startDate": "2024-11-06",
+    "endDate": "2024-11-08",
+    "city": "Malmö",
+    "country": "Sweden",
+    "online": false,
+    "locales": "EN",
+    "twitter": "@oredev"
   },
   {
     "name": "Heapcon",

--- a/conferences/2024/general.json
+++ b/conferences/2024/general.json
@@ -1346,6 +1346,17 @@
     "twitter": "@PASSDataSummit"
   },
   {
+    "name": "Oredev",
+    "url": "https://oredev.org/",
+    "startDate": "2024-11-06",
+    "endDate": "2024-11-08",
+    "city": "Malmö",
+    "country": "Sweden",
+    "online": false,
+    "locales": "EN",
+    "twitter": "@oredev"
+  },
+  {
     "name": "TURING x SYSTM Growth Summit",
     "url": "https://turingfest.com/turingxsystm",
     "startDate": "2024-11-06",

--- a/conferences/2024/java.json
+++ b/conferences/2024/java.json
@@ -341,6 +341,15 @@
     "twitter": "@devignition"
   },
   {
+    "name": "J-Fall",
+    "url": "https://jfall.nl/",
+    "startDate": "2024-11-07",
+    "endDate": "2024-11-07",
+    "city": "Ede",
+    "country": "Netherlands",
+    "locales": "EN"
+  },
+  {
     "name": "NODES",
     "url": "https://neo4j.com/nodes-2024",
     "startDate": "2024-11-07",
@@ -350,15 +359,6 @@
     "cfpUrl": "https://sessionize.com/nodes-2024",
     "cfpEndDate": "2024-06-15",
     "twitter": "@neo4j"
-  },
-  {
-    "name": "J-Fall",
-    "url": "https://jfall.nl/",
-    "startDate": "2024-11-07",
-    "endDate": "2024-11-07",
-    "city": "Ede",
-    "country": "Netherlands",
-    "locales": "EN"
   },
   {
     "name": "DevOps Vision",

--- a/conferences/2024/java.json
+++ b/conferences/2024/java.json
@@ -352,6 +352,15 @@
     "twitter": "@neo4j"
   },
   {
+    "name": "J-Fall",
+    "url": "https://jfall.nl/",
+    "startDate": "2024-11-07",
+    "endDate": "2024-11-07",
+    "city": "Ede",
+    "country": "Netherlands",
+    "locales": "EN"
+  },
+  {
     "name": "DevOps Vision",
     "url": "https://devopsvision.io",
     "startDate": "2024-12-02",

--- a/conferences/2025/general.json
+++ b/conferences/2025/general.json
@@ -14,6 +14,17 @@
     "twitter": "@codemash"
   },
   {
+    "name": "Voxxed Days CERN",
+    "url": "https://cern.voxxeddays.com/",
+    "startDate": "2025-01-15",
+    "endDate": "2025-01-15",
+    "city": "Geneva",
+    "country": "Switzerland",
+    "online": false,
+    "locales": "EN",
+    "twitter": "@voxxedzurich"
+  },
+  {
     "name": "Voxxed Days Ticino",
     "url": "https://ticino.voxxeddays.com",
     "startDate": "2025-01-17",

--- a/conferences/2025/java.json
+++ b/conferences/2025/java.json
@@ -1,5 +1,15 @@
 [
   {
+    "name": "Jfokus",
+    "url": "https://www.jfokus.se/",
+    "startDate": "2025-02-03",
+    "endDate": "2025-02-05",
+    "city": "Stockholm",
+    "country": "Sweden",
+    "online": false,
+    "locales": "EN"
+  },
+  {
     "name": "JavaLand",
     "url": "https://www.javaland.eu",
     "startDate": "2025-04-01",

--- a/conferences/2025/java.json
+++ b/conferences/2025/java.json
@@ -10,6 +10,17 @@
     "locales": "EN"
   },
   {
+    "name": "JavaOne",
+    "url": "https://www.oracle.com/javaone/",
+    "startDate": "2025-03-18",
+    "endDate": "2025-03-20",
+    "city": "Redwood City, CA",
+    "country": "U.S.A.",
+    "online": false,
+    "locales": "EN",
+    "twitter": "@JavaOne"
+  },
+  {
     "name": "JavaLand",
     "url": "https://www.javaland.eu",
     "startDate": "2025-04-01",


### PR DESCRIPTION
Thanks for creating a new Pull Request for this repository.

To get the conferce as fast as possible into confs.tech please consider the following things.

## Checklist for your change
- [x] does not delete another conference
- [x] has passed the tests via `npm run test`
- [x] has the correct order via `npm run reorder-confs`
- [x] is a developer conference: more than 3-4 people from different companies
- [x] is not a webinar, hackathon, marketing, zoom meeting with one person
- [x] URLs are reachable, as short as possible, do not contain tracking parameters and the website is dedicated for this event
- [x] topic is correct
- [x] conference name is as short as possible and does not include location and date
