### PR TITLE
added some confs for 2025, mostly in Germany

### DIFF
--- a/conferences/2025/data.json
+++ b/conferences/2025/data.json
@@ -9,6 +9,16 @@
     "cocUrl": "https://genai.bettercode.eu/code_of_conduct.php?source=0"
   },
   {
+    "name": "IEEE/SICE SII",
+    "url": "https://sice-si.org/SII2025/sii2025.html",
+    "startDate": "2025-01-21",
+    "endDate": "2025-01-24",
+    "city": "Munich",
+    "country": "Germany",
+    "online": false,
+    "locales": "EN"
+  },
+  {
     "name": "AI DevWorld",
     "url": "https://aidevworld.com",
     "startDate": "2025-02-11",

--- a/conferences/2025/general.json
+++ b/conferences/2025/general.json
@@ -63,6 +63,17 @@
     "twitter": "@coderful"
   },
   {
+    "name": "DecompileD",
+    "url": "https://decompiled.de/",
+    "startDate": "2025-02-06",
+    "endDate": "2025-02-06",
+    "city": "Dresden",
+    "country": "Germany",
+    "online": false,
+    "locales": "EN",
+    "cocUrl": "https://decompiled.de/verhaltenskodex"
+  },
+  {
     "name": "Civo Navigate",
     "url": "https://www.civo.com/navigate/north-america",
     "startDate": "2025-02-10",

--- a/conferences/2025/general.json
+++ b/conferences/2025/general.json
@@ -393,6 +393,16 @@
     "twitter": "@devops_con"
   },
   {
+    "name": "APIdays",
+    "url": "https://www.apidays.global/munich/",
+    "startDate": "2025-07-02",
+    "endDate": "2025-07-03",
+    "city": "Munich",
+    "country": "Germany",
+    "online": false,
+    "locales": "EN"
+  },
+  {
     "name": "WeAreDevelopers World Congress",
     "url": "https://www.wearedevelopers.com/world-congress",
     "startDate": "2025-07-09",

--- a/conferences/2025/javascript.json
+++ b/conferences/2025/javascript.json
@@ -178,6 +178,17 @@
     "twitter": "@appjsconf"
   },
   {
+    "name": "Webinale",
+    "url": "https://webinale.de",
+    "startDate": "2025-06-02",
+    "endDate": "2025-06-06",
+    "city": "Berlin",
+    "country": "Germany",
+    "online": true,
+    "locales": "EN",
+    "twitter": "@webinale"
+  },
+  {
     "name": "Web Summer Camp",
     "url": "https://websummercamp.com/2025",
     "startDate": "2025-07-03",

--- a/conferences/2025/php.json
+++ b/conferences/2025/php.json
@@ -63,17 +63,6 @@
     "twitter": "@symfony_live"
   },
   {
-    "name": "International PHP Conference",
-    "url": "https://phpconference.com/berlin-en/",
-    "startDate": "2025-06-02",
-    "endDate": "2025-06-06",
-    "city": "Berlin",
-    "country": "Germany",
-    "online": true,
-    "locales": "EN, DE",
-    "twitter": "@phpconference"
-  },
-  {
     "name": "php[tek]",
     "url": "https://phptek.io",
     "startDate": "2025-05-20",
@@ -87,6 +76,17 @@
     "cfpEndDate": "2024-11-15",
     "twitter": "@phptek",
     "mastodon": "@phptek@phparch.social"
+  },
+  {
+    "name": "International PHP Conference",
+    "url": "https://phpconference.com/berlin-en/",
+    "startDate": "2025-06-02",
+    "endDate": "2025-06-06",
+    "city": "Berlin",
+    "country": "Germany",
+    "online": true,
+    "locales": "EN, DE",
+    "twitter": "@phpconference"
   },
   {
     "name": "SymfonyOnline",

--- a/conferences/2025/php.json
+++ b/conferences/2025/php.json
@@ -63,6 +63,17 @@
     "twitter": "@symfony_live"
   },
   {
+    "name": "International PHP Conference",
+    "url": "https://phpconference.com/berlin-en/",
+    "startDate": "2025-06-02",
+    "endDate": "2025-06-06",
+    "city": "Berlin",
+    "country": "Germany",
+    "online": true,
+    "locales": "EN, DE",
+    "twitter": "@phpconference"
+  },
+  {
     "name": "php[tek]",
     "url": "https://phptek.io",
     "startDate": "2025-05-20",


### PR DESCRIPTION
Thanks for creating a new Pull Request for this repository.

To get the conferce as fast as possible into confs.tech please consider the following things.

## Checklist for your change
- [x] does not delete another conference
- [x] has passed the tests via `npm run test`
- [x] has the correct order via `npm run reorder-confs`
- [x] is a developer conference: more than 3-4 people from different companies
- [x] is not a webinar, hackathon, marketing, zoom meeting with one person
- [x] URLs are reachable, as short as possible, do not contain tracking parameters and the website is dedicated for this event
- [x] topic is correct
- [x] conference name is as short as possible and does not include location and date
