### PR TITLE
feat: add bluesky data field for conferences

### DIFF
--- a/.github/ISSUE_TEMPLATE/suggest-new-location.md
+++ b/.github/ISSUE_TEMPLATE/suggest-new-location.md
@@ -23,7 +23,7 @@ If you would like to suggest a conference, please also list the details of the c
 - topic:
 - language:
 - is the conference onsite or hybrid?
-- twitter/mastodon handle
+- bluesky/mastodon/twitter handle
 - code of conduct
 
 Is there anything else we can help you with?

--- a/scripts/config/validFields.ts
+++ b/scripts/config/validFields.ts
@@ -11,7 +11,8 @@ export default [
     'cocUrl',
     'cfpUrl',
     'cfpEndDate',
+    'bluesky',
+    'mastodon',
     'twitter',
-    'github',
-    'mastodon'
+    'github'
 ];

--- a/scripts/reorderConferencesByDate.ts
+++ b/scripts/reorderConferencesByDate.ts
@@ -63,9 +63,10 @@ Object.keys(conferencesJSON).forEach(year => {
                         cocUrl: mergedConference.cocUrl,
                         cfpUrl: mergedConference.cfpUrl,
                         cfpEndDate: mergedConference.cfpEndDate,
-                        twitter: mergedConference.twitter,
+                        bluesky: mergedConference.bluesky,
                         github: mergedConference.github,
-                        mastodon: mergedConference.mastodon
+                        mastodon: mergedConference.mastodon,
+                        twitter: mergedConference.twitter
                     };
                     return conference;
                 });

--- a/scripts/utils/Conference.ts
+++ b/scripts/utils/Conference.ts
@@ -11,7 +11,8 @@ export interface Conference {
     cocUrl: string;
     cfpUrl: string;
     cfpEndDate: string;
-    twitter: string;
+    bluesky: string;
     github: string;
     mastodon: string;
+    twitter: string;
 }


### PR DESCRIPTION
Thanks for creating a new Pull Request for this repository.

To get the conference as fast as possible into confs.tech please consider the following things.

## Checklist for your change
- [x] does not delete another conference
- [x] has passed the tests via `npm run test`
- [x] has the correct order via `npm run reorder-confs`
- [x] is a developer conference: more than 3-4 people from different companies
- [x] is not a webinar, hackathon, marketing, zoom meeting with one person
- [x] URLs are reachable, as short as possible, do not contain tracking parameters and the website is dedicated for this event
- [x] topic is correct
- [x] conference name is as short as possible and does not include location and date

_(this isn't adding a conf, but hey - it still passes the checklist anyway!)_

---

Fixes #7509 on this repo's end. I'll send separate PRs for the other repos too.

Just pipes the data through without adding any validations. I considered adding one to `script/utils/checkConference.ts` but 🤷 I'm not positive on the right way to validate a bsky handle.