### PR TITLE
Tokyo Test Fest 2025

### DIFF
--- a/conferences/2025/testing.json
+++ b/conferences/2025/testing.json
@@ -105,5 +105,19 @@
     "cfpUrl": "https://automation.eurostarsoftwaretesting.com/call-for-speakers",
     "cfpEndDate": "2025-02-15",
     "twitter": "@AutomationConf"
+  },
+  {
+    "name": "Tokyo Test Fest",
+    "url": "https://tokyotestfest.com",
+    "startDate": "2025-11-14",
+    "endDate": "2025-11-14",
+    "city": "Tokyo",
+    "country": "Japan",
+    "online": false,
+    "locales": "EN,JA",
+    "cocUrl": "https://tokyotestfest.com/code_of_conduct/",
+    "cfpUrl": "https://forms.gle/digCBTMSELLxM6Pb9",
+    "cfpEndDate": "2025-04-20",
+    "twitter": "@tokyotestfest"
   }
 ]


### PR DESCRIPTION
Thanks for creating a new Pull Request for this repository.

To get the conference as fast as possible into confs.tech please consider the following things.

## Checklist for your change
- [ ] does not delete another conference
- [ ] has passed the tests via `npm run test`
- [ ] has the correct order via `npm run reorder-confs`
- [ ] is a developer conference: more than 3-4 people from different companies
- [ ] is not a webinar, hackathon, marketing, zoom meeting with one person
- [ ] URLs are reachable, as short as possible, do not contain tracking parameters and the website is dedicated for this event
- [ ] topic is correct
- [ ] conference name is as short as possible and does not include location and date
