### PR TITLE
Adding Conf: Pixel Pioneers Bristol

### DIFF
--- a/conferences/2025/general.json
+++ b/conferences/2025/general.json
@@ -531,6 +531,20 @@
     "twitter": "@devops_con"
   },
   {
+    "name": "Pixel Pioneers",
+    "url": "https://pixelpioneers.co/events/bristol-2025",
+    "startDate": "2025-06-20",
+    "endDate": "2025-06-20",
+    "city": "Bristol",
+    "country": "U.K.",
+    "online": false,
+    "locales": "EN",
+    "cocUrl": "https://pixelpioneers.co/code-of-conduct",
+    "cfpUrl": "https://pixelpioneers.co/call-for-speakers",
+    "cfpEndDate": "2025-04-14",
+    "twitter": "@pixelpioneers"
+  },
+  {
     "name": "APIdays",
     "url": "https://www.apidays.global/munich/",
     "startDate": "2025-07-02",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "clarinet": "^0.12.4",
         "date-fns": "^3.6.0",
         "string-similarity-js": "^2.1.4",
-        "tsx": "^4.19.2",
         "typescript": "^5.5.4"
       },
       "devDependencies": {
@@ -23,7 +22,8 @@
         "git-json-merge": "^1.0.0",
         "lodash": "^4.17.21",
         "nodemon": "^3.1.4",
-        "prettier": "^3.3.3"
+        "prettier": "^3.3.3",
+        "tsx": "^4.19.2"
       }
     },
     "node_modules/@actions/github": {
@@ -53,6 +53,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -593,6 +594,7 @@
       "version": "0.23.1",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.23.1.tgz",
       "integrity": "sha512-VVNz/9Sa0bs5SELtn3f7qhJCDPCF5oMEl5cO9/SSinpE9hbPVvxbd572HH5AKiP7WD8INO53GgfDDhRjkylHEg==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -644,6 +646,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -657,6 +660,7 @@
       "version": "4.7.6",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.7.6.tgz",
       "integrity": "sha512-ZAqrLlu18NbDdRaHq+AKXzAmqIUPswPWKUchfytdAjiRFnCe5ojG2bstg6mRiZabkKfCoL/e98pbBELIV/YCeA==",
+      "dev": true,
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
       },
@@ -894,6 +898,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
@@ -970,7 +975,7 @@
       "version": "4.19.2",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.19.2.tgz",
       "integrity": "sha512-pOUl6Vo2LUq/bSa8S5q7b91cgNSjctn9ugq/+Mvow99qW6x/UZYwzxy/3NmqoT66eHYfCVvFvACC58UBPFf28g==",
-      "license": "MIT",
+      "dev": true,
       "dependencies": {
         "esbuild": "~0.23.0",
         "get-tsconfig": "^4.7.5"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "clarinet": "^0.12.4",
     "date-fns": "^3.6.0",
     "string-similarity-js": "^2.1.4",
-    "tsx": "^4.19.2",
     "typescript": "^5.5.4"
   },
   "devDependencies": {
@@ -17,7 +16,8 @@
     "git-json-merge": "^1.0.0",
     "lodash": "^4.17.21",
     "nodemon": "^3.1.4",
-    "prettier": "^3.3.3"
+    "prettier": "^3.3.3",
+    "tsx": "^4.19.2"
   },
   "scripts": {
     "start": "tsx watch --include './conferences/**/*' ./scripts/conferences.test.ts",


### PR DESCRIPTION
install tsx to be able to run scripts local
closes #7526

Thanks for creating a new Pull Request for this repository.

To get the conference as fast as possible into confs.tech please consider the following things.

## Checklist for your change
- [ ] does not delete another conference
- [ ] has passed the tests via `npm run test`
- [ ] has the correct order via `npm run reorder-confs`
- [ ] is a developer conference: more than 3-4 people from different companies
- [ ] is not a webinar, hackathon, marketing, zoom meeting with one person
- [ ] URLs are reachable, as short as possible, do not contain tracking parameters and the website is dedicated for this event
- [ ] topic is correct
- [ ] conference name is as short as possible and does not include location and date
