### PR TITLE
Moved Tech Internals Conference to general

### DIFF
--- a/conferences/2025/data.json
+++ b/conferences/2025/data.json
@@ -383,17 +383,6 @@
     "twitter": "@mlconference"
   },
   {
-    "name": "Tech Internals Conference",
-    "url": "https://internals.tech/berlin/2025",
-    "startDate": "2025-05-26",
-    "endDate": "2025-05-26",
-    "city": "Berlin",
-    "country": "Germany",
-    "online": false,
-    "locales": "EN",
-    "cocUrl": "https://internals.tech/documents/tech_internals_conf/2024/code-of-conduct.html"
-  },
-  {
     "name": "IT-GRC-Kongress",
     "url": "https://www.grc-kongress.de",
     "startDate": "2025-05-26",

--- a/conferences/2025/devops.json
+++ b/conferences/2025/devops.json
@@ -351,17 +351,6 @@
     "twitter": "@DevOpsDaysPrg"
   },
   {
-    "name": "Tech Internals Conference",
-    "url": "https://internals.tech/berlin/2025",
-    "startDate": "2025-05-26",
-    "endDate": "2025-05-26",
-    "city": "Berlin",
-    "country": "Germany",
-    "online": false,
-    "locales": "EN",
-    "cocUrl": "https://internals.tech/documents/tech_internals_conf/2024/code-of-conduct.html"
-  },
-  {
     "name": "OWASP Global AppSec EU",
     "url": "https://owasp.glueup.com/event/owasp-global-appsec-eu-2025-123983",
     "startDate": "2025-05-26",

--- a/conferences/2025/general.json
+++ b/conferences/2025/general.json
@@ -434,6 +434,17 @@
     "twitter": "@NZTechRally"
   },
   {
+    "name": "Tech Internals Conference",
+    "url": "https://internals.tech/berlin/2025",
+    "startDate": "2025-05-26",
+    "endDate": "2025-05-26",
+    "city": "Berlin",
+    "country": "Germany",
+    "online": false,
+    "locales": "EN",
+    "cocUrl": "https://internals.tech/documents/tech_internals_conf/2024/code-of-conduct.html"
+  },
+  {
     "name": "myConf",
     "url": "https://myconf.io",
     "startDate": "2025-05-26",

--- a/conferences/2025/networking.json
+++ b/conferences/2025/networking.json
@@ -111,17 +111,6 @@
     "twitter": "@GITEXEUROPE"
   },
   {
-    "name": "Tech Internals Conference",
-    "url": "https://internals.tech/berlin/2025",
-    "startDate": "2025-05-26",
-    "endDate": "2025-05-26",
-    "city": "Berlin",
-    "country": "Germany",
-    "online": false,
-    "locales": "EN",
-    "cocUrl": "https://internals.tech/documents/tech_internals_conf/2024/code-of-conduct.html"
-  },
-  {
     "name": "CTO Craft Con: Toronto",
     "url": "https://conference.ctocraft.com/toronto-2025",
     "startDate": "2025-05-27",


### PR DESCRIPTION
moved Tech Internals Conference to general requested on #7650

Thanks for creating a new Pull Request for this repository.

To get the conference as fast as possible into confs.tech please consider the following things.

## Checklist for your change
- [ ] does not delete another conference
- [x] has passed the tests via `npm run test`
- [x] has the correct order via `npm run reorder-confs`
- [x] is a developer conference: more than 3-4 people from different companies
- [x] is not a webinar, hackathon, marketing, zoom meeting with one person
- [x] URLs are reachable, as short as possible, do not contain tracking parameters and the website is dedicated for this event
- [x] topic is correct
- [x] conference name is as short as possible and does not include location and date
