### PR TITLE
Update trigger on workflow to run every 3 months

### DIFF
--- a/.github/workflows/check_links.yaml
+++ b/.github/workflows/check_links.yaml
@@ -2,7 +2,7 @@ name: Check links
 
 on:
     schedule:
-        - cron: '16 2 * * 6'
+        - cron: '0 11 1 1,4,7,10 *'
 
 jobs:
     validate:


### PR DESCRIPTION
Thanks for creating a new Pull Request for this repository.

To get the conference as fast as possible into confs.tech please consider the following things.

## Checklist for your change
- [ ] does not delete another conference
- [ ] has passed the tests via `npm run test`
- [ ] has the correct order via `npm run reorder-confs`
- [ ] is a developer conference: more than 3-4 people from different companies
- [ ] is not a webinar, hackathon, marketing, zoom meeting with one person
- [ ] URLs are reachable, as short as possible, do not contain tracking parameters and the website is dedicated for this event
- [ ] topic is correct
- [ ] conference name is as short as possible and does not include location and date
