### PR TITLE
Fix Broken links

### DIFF
--- a/conferences/2022/devops.json
+++ b/conferences/2022/devops.json
@@ -914,8 +914,6 @@
     "country": "Spain",
     "online": false,
     "cocUrl": "https://devops.barcelona/code-of-conduct",
-    "cfpUrl": "https://devops.barcelona/call-for-papers",
-    "cfpEndDate": "2022-06-30",
     "twitter": "@devopsbarcelona"
   },
   {

--- a/conferences/2023/javascript.json
+++ b/conferences/2023/javascript.json
@@ -577,7 +577,6 @@
     "country": "U.S.A.",
     "online": false,
     "locales": "EN",
-    "cocUrl": "https://utahjs.com/conduct",
     "cfpUrl": "https://sessionize.com/utahjs-conf-2023",
     "cfpEndDate": "2023-05-01",
     "twitter": "@utjs"

--- a/conferences/2024/devops.json
+++ b/conferences/2024/devops.json
@@ -1092,8 +1092,6 @@
     "online": false,
     "locales": "EN",
     "cocUrl": "https://devops.barcelona/code-of-conduct?utm_source=confs.tech&utm_medium=link&utm_campaign=devops-barcelona-2024&utm_id=devops-barcelona-2024",
-    "cfpUrl": "https://devops.barcelona/call-for-papers",
-    "cfpEndDate": "2024-06-30",
     "twitter": "@devopsbarcelona"
   },
   {

--- a/conferences/2024/javascript.json
+++ b/conferences/2024/javascript.json
@@ -591,7 +591,6 @@
     "country": "U.S.A.",
     "online": false,
     "locales": "EN",
-    "cocUrl": "https://utahjs.com/conduct",
     "cfpUrl": "https://sessionize.com/utahjs-conf-2024",
     "cfpEndDate": "2024-04-07",
     "twitter": "@utjs"

--- a/conferences/2025/data.json
+++ b/conferences/2025/data.json
@@ -93,9 +93,7 @@
     "country": "Germany",
     "online": false,
     "locales": "EN",
-    "cocUrl": "https://www.oc3.dev/code-of-conduct",
-    "cfpUrl": "https://www.oc3.dev/call-for-submissions",
-    "cfpEndDate": "2024-12-13"
+    "cocUrl": "https://www.oc3.dev/code-of-conduct"
   },
   {
     "name": "WebDev & AI Day",
@@ -169,8 +167,6 @@
     "country": "Germany",
     "online": true,
     "locales": "EN",
-    "cocUrl": "https://pioneershub.github.io/pyconde25-conference/code-of-conduct/",
-    "cfpUrl": "https://2025.pycon.de/call-for-proposals",
     "cfpEndDate": "2025-01-05",
     "twitter": "@pyconde",
     "mastodon": "@pyconde@fosstodon.org"
@@ -509,8 +505,6 @@
     "country": "U.S.A.",
     "online": false,
     "locales": "EN",
-    "cfpUrl": "https://www.papercall.io/ai-in-production-2025",
-    "cfpEndDate": "2025-04-30",
     "twitter": "@AIinProduction"
   },
   {

--- a/conferences/2025/devops.json
+++ b/conferences/2025/devops.json
@@ -101,8 +101,6 @@
     "online": false,
     "locales": "EN,DE",
     "cocUrl": "https://www.javaland.eu/de/verhaltenscodex",
-    "cfpUrl": "https://www.javaland.eu/de/referierende",
-    "cfpEndDate": "2024-09-06",
     "twitter": "@DOAGeV",
     "mastodon": "@JavaLandConf@ijug.social"
   },
@@ -672,8 +670,6 @@
     "online": false,
     "locales": "EN",
     "cocUrl": "https://devops.barcelona/code-of-conduct",
-    "cfpUrl": "https://devops.barcelona/call-for-papers",
-    "cfpEndDate": "2025-07-15",
     "twitter": "@devopsbarcelona"
   },
   {

--- a/conferences/2025/dotnet.json
+++ b/conferences/2025/dotnet.json
@@ -80,7 +80,6 @@
     "country": "Sweden",
     "online": false,
     "locales": "SV",
-    "cocUrl": "https://www.umbracokalaset.se/code-of-conduct",
     "twitter": "@umbracokalaset"
   },
   {

--- a/conferences/2025/general.json
+++ b/conferences/2025/general.json
@@ -683,7 +683,6 @@
     "country": "U.S.A.",
     "online": false,
     "locales": "EN",
-    "cocUrl": "https://utahjs.com/conduct",
     "cfpUrl": "https://sessionize.com/utahjs-conf-2025",
     "cfpEndDate": "2025-04-07",
     "twitter": "@utjs"

--- a/conferences/2025/java.json
+++ b/conferences/2025/java.json
@@ -30,8 +30,6 @@
     "online": false,
     "locales": "EN,DE",
     "cocUrl": "https://www.javaland.eu/de/verhaltenscodex",
-    "cfpUrl": "https://www.javaland.eu/de/referierende",
-    "cfpEndDate": "2024-09-06",
     "twitter": "@DOAGeV",
     "mastodon": "@JavaLandConf@ijug.social"
   },

--- a/conferences/2025/javascript.json
+++ b/conferences/2025/javascript.json
@@ -131,8 +131,6 @@
     "online": false,
     "locales": "EN,DE",
     "cocUrl": "https://www.javaland.eu/de/verhaltenscodex",
-    "cfpUrl": "https://www.javaland.eu/de/referierende",
-    "cfpEndDate": "2024-09-06",
     "twitter": "@DOAGeV",
     "mastodon": "@JavaLandConf@ijug.social"
   },

--- a/conferences/2025/leadership.json
+++ b/conferences/2025/leadership.json
@@ -22,20 +22,6 @@
     "twitter": "@ctocraft"
   },
   {
-    "name": "L8Conf",
-    "url": "https://l8conf.com",
-    "startDate": "2025-03-17",
-    "endDate": "2025-03-18",
-    "city": "Warsaw",
-    "country": "Poland",
-    "online": false,
-    "locales": "EN",
-    "cocUrl": "https://l8conf.com/#codeofconduct",
-    "cfpUrl": "https://forms.gle/VbjNRQSGCQJ7Yp246",
-    "cfpEndDate": "2024-12-01",
-    "twitter": "@l8conf"
-  },
-  {
     "name": "Leadership Ateliers Lisbon",
     "url": "https://www.leadershipateliers.com/lisbon",
     "startDate": "2025-04-23",

--- a/conferences/2025/networking.json
+++ b/conferences/2025/networking.json
@@ -34,9 +34,7 @@
     "country": "Germany",
     "online": false,
     "locales": "EN",
-    "cocUrl": "https://www.oc3.dev/code-of-conduct",
-    "cfpUrl": "https://www.oc3.dev/call-for-submissions",
-    "cfpEndDate": "2024-12-13"
+    "cocUrl": "https://www.oc3.dev/code-of-conduct"
   },
   {
     "name": "11th Data Management ThinkLab",

--- a/conferences/2025/opensource.json
+++ b/conferences/2025/opensource.json
@@ -25,18 +25,6 @@
     "mastodon": "@fosdem@fosstodon.org"
   },
   {
-    "name": "CFGMGMTCAMP",
-    "url": "https://www.cfgmgmtcamp.eu/ghent2025/",
-    "startDate": "2025-02-03",
-    "endDate": "2025-02-05",
-    "city": "Ghent",
-    "country": "Belgium",
-    "online": false,
-    "locales": "EN",
-    "cocUrl": "https://www.cfgmgmtcamp.eu/ghent2025/codeofconduct/",
-    "twitter": "@cfgmgmtcamp"
-  },
-  {
     "name": "FOSS Backstage",
     "url": "https://25.foss-backstage.de",
     "startDate": "2025-03-10",

--- a/conferences/2025/php.json
+++ b/conferences/2025/php.json
@@ -90,19 +90,6 @@
     "mastodon": "@phptek@phparch.social"
   },
   {
-    "name": "PHPers Summit",
-    "url": "https://summit.phpers.pl/en/",
-    "startDate": "2025-05-23",
-    "endDate": "2025-05-25",
-    "city": "Poznań",
-    "country": "Poland",
-    "online": false,
-    "locales": "EN, PL",
-    "cfpUrl": "https://summit.phpers.pl/en/call-for-papers",
-    "cfpEndDate": "2025-01-31",
-    "twitter": "@PHPersPL"
-  },
-  {
     "name": "PHPers Day Poznań",
     "url": "https://phpers.day",
     "startDate": "2025-05-24",

--- a/conferences/2025/python.json
+++ b/conferences/2025/python.json
@@ -48,8 +48,6 @@
     "country": "Germany",
     "online": true,
     "locales": "EN",
-    "cocUrl": "https://pioneershub.github.io/pyconde25-conference/code-of-conduct/",
-    "cfpUrl": "https://2025.pycon.de/call-for-proposals",
     "cfpEndDate": "2025-01-05",
     "twitter": "@pyconde",
     "mastodon": "@pyconde@fosstodon.org"

--- a/conferences/2025/security.json
+++ b/conferences/2025/security.json
@@ -68,9 +68,7 @@
     "country": "Germany",
     "online": false,
     "locales": "EN",
-    "cocUrl": "https://www.oc3.dev/code-of-conduct",
-    "cfpUrl": "https://www.oc3.dev/call-for-submissions",
-    "cfpEndDate": "2024-12-13"
+    "cocUrl": "https://www.oc3.dev/code-of-conduct"
   },
   {
     "name": "heise devSec: KI und Security",

--- a/conferences/2025/ux.json
+++ b/conferences/2025/ux.json
@@ -8,8 +8,7 @@
     "country": "U.S.A.",
     "online": true,
     "locales": "EN",
-    "offersSignLanguageOrCC": true,
-    "cocUrl": "https://conveyux.com/conveyux-code-conduct/"
+    "offersSignLanguageOrCC": true
   },
   {
     "name": "Leadership Ateliers Lisbon",


### PR DESCRIPTION
closes #7803

This pull request involves updates to the conference data files, primarily removing outdated Call for Proposals (CFP) URLs and end dates, as well as some Code of Conduct (CoC) URLs. Additionally, several conferences have been removed entirely from the dataset. Below is a categorized summary of the most important changes:

### Removal of CFP Details:
* Removed `cfpUrl` and `cfpEndDate` for multiple conferences across various years and topics, including `DevOps Barcelona`, `UtahJS Conf`, `AI in Production`, and others. [[1]](diffhunk://#diff-eac83f0dfd55152a1ad5a3b41bbd249b4e6a337d8419d094c74077b66047683dL917-L918) [[2]](diffhunk://#diff-e10dfacd12b4470471df280d9e651b7623ac9259b3e26240c91d4a6c2972697dL580) [[3]](diffhunk://#diff-34d85d75e8956e6bc024d330f81082b5811984e52ae5f514cf848218ee3cd723L675-L676) [[4]](diffhunk://#diff-04d0c07086854112891dd35d0d8abcba8e08f6dcd6fc41aef3d9db2550f4fa32L512-L513)

### Removal of Conferences:
* Entirely removed conferences such as `L8Conf`, `CFGMGMTCAMP`, and `PHPers Summit` from the dataset. [[1]](diffhunk://#diff-e3d4a0603212e099d7cf637bf1721b408b2c2cdbe9a1de554dff55cf29d1b367L24-L37) [[2]](diffhunk://#diff-aeedeeeb7a4dca478d574f0bdce70901255410cdbfb5fd58b34c39e9128dc54cL27-L38) [[3]](diffhunk://#diff-e600c18a1083ad970a2c4635b51907097901bab1bde9eb6a3212cfa3b6df2d49L92-L104)

### Updates to CoC URLs:
* Updated or removed outdated CoC URLs for conferences like `DevOps Barcelona`, `PyConDE`, and `OC3`. [[1]](diffhunk://#diff-8273fff3cdf166162b8dd38a3ee52a0ef91030a277ff234109ee16140abf337dL1095-L1096) [[2]](diffhunk://#diff-6cb7673061c9fd87fdf4efa58ac60f64d25580a073db5bc74d419a50bfb2cdecL51-L52) [[3]](diffhunk://#diff-3e1d9bf4abec8acd3e2052e7e141ef2c8aeaeff79bec4c87336efec96d1b4343L37-R37)

### Other Adjustments:
* Removed `offersSignLanguageOrCC` from `ConveyUX` conference entry.

These changes streamline the conference data by removing outdated or irrelevant information, ensuring the dataset remains accurate and manageable.
Thanks for creating a new Pull Request for this repository.

To get the conference as fast as possible into confs.tech please consider the following things.

## Checklist for your change
- [ ] does not delete another conference
- [ ] has passed the tests via `npm run test`
- [ ] has the correct order via `npm run reorder-confs`
- [ ] is a developer conference: more than 3-4 people from different companies
- [ ] is not a webinar, hackathon, marketing, zoom meeting with one person
- [ ] URLs are reachable, as short as possible, do not contain tracking parameters and the website is dedicated for this event
- [ ] topic is correct
- [ ] conference name is as short as possible and does not include location and date
