### PR TITLE
Updated CfP for InnerSource Summit 2025

### DIFF
--- a/conferences/2025/opensource.json
+++ b/conferences/2025/opensource.json
@@ -370,7 +370,7 @@
     "locales": "EN",
     "cocUrl": "https://innersourcecommons.org/about/codeofconduct/",
     "cfpUrl": "https://docs.google.com/forms/d/e/1FAIpQLSfWKkRDWIYN8eTOMlxONZp23-_i9nnAfqSJm26QCdzS5NtO9w/viewform",
-    "cfpEndDate": "2025-07-15",
+    "cfpEndDate": "2025-08-31",
     "twitter": "@InnerSourceOrg"
   },
   {
@@ -384,7 +384,7 @@
     "locales": "EN",
     "cocUrl": "https://innersourcecommons.org/about/codeofconduct/",
     "cfpUrl": "https://docs.google.com/forms/d/e/1FAIpQLSfWKkRDWIYN8eTOMlxONZp23-_i9nnAfqSJm26QCdzS5NtO9w/viewform",
-    "cfpEndDate": "2025-07-15",
+    "cfpEndDate": "2025-08-31",
     "twitter": "@InnerSourceOrg"
   },
   {
@@ -398,7 +398,7 @@
     "locales": "EN",
     "cocUrl": "https://innersourcecommons.org/about/codeofconduct/",
     "cfpUrl": "https://docs.google.com/forms/d/e/1FAIpQLSfWKkRDWIYN8eTOMlxONZp23-_i9nnAfqSJm26QCdzS5NtO9w/viewform",
-    "cfpEndDate": "2025-07-15",
+    "cfpEndDate": "2025-08-31",
     "twitter": "@InnerSourceOrg"
   }
 ]


### PR DESCRIPTION
CfP for InnerSource summit 2025 was postponed.

Thanks for creating a new Pull Request for this repository.

To get the conference as fast as possible into confs.tech please consider the following things.

## Checklist for your change
- [x] does not delete another conference
- [x] has passed the tests via `npm run test`
- [x] has the correct order via `npm run reorder-confs`
- [x] is a developer conference: more than 3-4 people from different companies
- [x] is not a webinar, hackathon, marketing, zoom meeting with one person
- [x] URLs are reachable, as short as possible, do not contain tracking parameters and the website is dedicated for this event
- [x] topic is correct
- [x] conference name is as short as possible and does not include location and date
