### PR TITLE
Update java.json

### DIFF
--- a/conferences/2026/java.json
+++ b/conferences/2026/java.json
@@ -24,6 +24,8 @@
     "online": false,
     "locales": "EN",
     "cocUrl": "https://2026.europe.jcon.one/code-of-conduct",
+    "cfpUrl": "https://sessionize.com/jcon-europe-2026",
+    "cfpEndDate": "2025-10-24",
     "twitter": "@jcon_conference"
   },
   {


### PR DESCRIPTION
Added CFP details for JCON EUROPE 2026

Thanks for creating a new Pull Request for this repository.

To get the conference as fast as possible into confs.tech please consider the following things.

## Checklist for your change
- [ ] does not delete another conference
- [ ] has passed the tests via `npm run test`
- [ ] has the correct order via `npm run reorder-confs`
- [ ] is a developer conference: more than 3-4 people from different companies
- [ ] is not a webinar, hackathon, marketing, zoom meeting with one person
- [ ] URLs are reachable, as short as possible, do not contain tracking parameters and the website is dedicated for this event
- [ ] topic is correct
- [ ] conference name is as short as possible and does not include location and date
