### PR TITLE
Added Tokyo Test Fest 2026

### DIFF
--- a/conferences/2026/testing.json
+++ b/conferences/2026/testing.json
@@ -24,5 +24,17 @@
     "cocUrl": "https://conference.eurostarsoftwaretesting.com/anti-harassment-policy/",
     "cfpUrl": "https://conference.eurostarsoftwaretesting.com/call-for-submissions",
     "cfpEndDate": "2025-10-13"
+  },
+  {
+    "name": "Tokyo Test Fest",
+    "url": "https://tokyotestfest.com",
+    "startDate": "2026-11-12",
+    "endDate": "2026-11-13",
+    "city": "Tokyo",
+    "country": "Japan",
+    "online": false,
+    "locales": "EN,JA",
+    "cocUrl": "https://tokyotestfest.com/code_of_conduct/",
+    "twitter": "@tokyotestfest"
   }
 ]


### PR DESCRIPTION
Thanks for creating a new Pull Request for this repository.

To get the conference as fast as possible into confs.tech please consider the following things.

## Checklist for your change
- [ ] does not delete another conference
- [ ] has passed the tests via `npm run test`
- [ ] has the correct order via `npm run reorder-confs`
- [ ] is a developer conference: more than 3-4 people from different companies
- [ ] is not a webinar, hackathon, marketing, zoom meeting with one person
- [ ] URLs are reachable, as short as possible, do not contain tracking parameters and the website is dedicated for this event
- [ ] topic is correct
- [ ] conference name is as short as possible and does not include location and date
