### PR TITLE
Add workflow to add a comment when non-dev-related label is added manually

### DIFF
--- a/.github/workflows/comment_on_label.yml
+++ b/.github/workflows/comment_on_label.yml
@@ -1,0 +1,23 @@
+name: Comment on non-dev conference
+
+on:
+    pull_request:
+        types: [labeled]
+
+jobs:
+    comment-on-label:
+        runs-on: ubuntu-latest
+        if: github.event.label.name == 'non-dev-related'
+
+        steps:
+            - name: Add comment for non-dev-related label
+              uses: actions/github-script@v8
+              with:
+                  github-token: ${{ github.token }}
+                  script: |
+                      await github.rest.issues.createComment({
+                        issue_number: context.issue.number,
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        body: 'This PR appears to add a non-dev-related conference and therefore, this event is out of scope of confs.tech. If you believe this is an error, please let us know. Thank you!'
+                      });


### PR DESCRIPTION
The existing automation that automatically checks the conference name to categorise it as dev- or non-dev-related doesn't work reliably. I've disabled it for now and proposing a simpler automation that would help add a comment for non-dev events before closing a PR.