### PR TITLE
CFP info for Tokyo Test Fest is added

### DIFF
--- a/conferences/2026/testing.json
+++ b/conferences/2026/testing.json
@@ -95,7 +95,6 @@
     "locales": "EN,JA",
     "cocUrl": "https://tokyotestfest.com/code_of_conduct/",
     "cfpUrl": "https://tokyotestfest.com/en/cfp_2026/",
-    "cfpStartDate": "2026-02-02",
     "cfpEndDate": "2026-04-10",
     "twitter": "@tokyotestfest"
   }


### PR DESCRIPTION
Thanks for creating a new Pull Request for this repository.

To get the conference as fast as possible into confs.tech please consider the following things.

## Checklist for your change
- [x] does not delete another conference
- [x] has passed the tests via `npm run test`
- [x] has the correct order via `npm run reorder-confs`
- [x] is a developer conference: more than 3-4 people from different companies
- [x] is not a webinar, hackathon, marketing, zoom meeting with one person
- [x] URLs are reachable, as short as possible, do not contain tracking parameters and the website is dedicated for this event
- [x] topic is correct
- [x] conference name is as short as possible and does not include location and date
