### PR TITLE
Move L8Conf to September

### DIFF
--- a/conferences/2026/leadership.json
+++ b/conferences/2026/leadership.json
@@ -9,18 +9,6 @@
     "cocUrl": "https://impact.inside-agile.de/code_of_conduct.php"
   },
   {
-    "name": "L8Conf",
-    "url": "https://l8conf.com",
-    "startDate": "2026-04-16",
-    "endDate": "2026-04-17",
-    "city": "Warsaw",
-    "country": "Poland",
-    "online": false,
-    "locales": "EN",
-    "cfpUrl": "https://docs.google.com/forms/d/e/1FAIpQLSfEDjOe18HZSToF4yfUCGgK3M5045VTtJLYTYuVYezIrjHqKA/viewform",
-    "cfpEndDate": "2025-12-31"
-  },
-  {
     "name": "UXDX EMEA",
     "url": "https://uxdx.com/berlin/2026",
     "startDate": "2026-05-27",
@@ -56,6 +44,19 @@
     "online": false,
     "locales": "EN",
     "offersSignLanguageOrCC": true
+  },
+  {
+    "name": "L8Conf",
+    "url": "https://l8conf.com",
+    "startDate": "2026-09-21",
+    "endDate": "2026-09-22",
+    "city": "Warsaw",
+    "country": "Poland",
+    "online": false,
+    "locales": "EN",
+    "cocUrl": "https://2026.l8conf.com/#codeofconduct",
+    "cfpUrl": "https://docs.google.com/forms/d/e/1FAIpQLSfEDjOe18HZSToF4yfUCGgK3M5045VTtJLYTYuVYezIrjHqKA/viewform",
+    "cfpEndDate": "2026-03-21"
   },
   {
     "name": "LeadDev Berlin",


### PR DESCRIPTION
Thanks for creating a new Pull Request for this repository.

To get the conference as fast as possible into confs.tech please consider the following things.

## Checklist for your change
- [X] does not delete another conference
- [X] has passed the tests via `npm run test`
- [X] has the correct order via `npm run reorder-confs`
- [X] is a developer conference: more than 3-4 people from different companies
- [X] is not a webinar, hackathon, marketing, zoom meeting with one person
- [X] URLs are reachable, as short as possible, do not contain tracking parameters and the website is dedicated for this event
- [X] topic is correct
- [X] conference name is as short as possible and does not include location and date
