### PR TITLE
Add SciPy 2026

### DIFF
--- a/conferences/2026/python.json
+++ b/conferences/2026/python.json
@@ -49,6 +49,21 @@
     "cocUrl": "https://websummercamp.com/2026/code-of-conduct"
   },
   {
+    "name": "SciPy",
+    "url": "https://www.scipy2026.scipy.org/",
+    "startDate": "2026-07-13",
+    "endDate": "2026-07-19",
+    "city": "Minneapolis, MN",
+    "country": "U.S.A.",
+    "online": false,
+    "locales": "EN",
+    "cocUrl": "https://numfocus.org/code-of-conduct",
+    "cfpUrl": "https://pretalx.com/scipy-2026/cfp",
+    "cfpEndDate": "2026-02-25",
+    "bluesky": "scipyconf.bsky.social",
+    "mastodon": "@SciPyConf"
+  },
+  {
     "name": "Global Summit on Data Science and Cloud Computing",
     "url": "https://datascience.novelticsconferences.com",
     "startDate": "2026-10-19",


### PR DESCRIPTION
Adds the SciPy (U.S.) conference.

## Checklist for your change

- [x] does not delete another conference
- [x] has passed the tests via `npm run test`
- [x] has the correct order via `npm run reorder-confs`
- [x] is a developer conference: more than 3-4 people from different companies
- [x] is not a webinar, hackathon, marketing, zoom meeting with one person
- [x] URLs are reachable, as short as possible, do not contain tracking parameters and the website is dedicated for this event
- [x] topic is correct
- [x] conference name is as short as possible and does not include location and date

## Question for Reviewers

What do we (SciPy conference) need to do to automatically get picked up by @confs-tech-bot , like https://github.com/tech-conferences/conference-data/pull/8276 ?

Thanks for your time and consideration.