### PR TITLE
Add the SciPy India 2026 conference

### DIFF
--- a/conferences/2026/data.json
+++ b/conferences/2026/data.json
@@ -1070,5 +1070,18 @@
     "cfpUrl": "https://aiconference.dev/cfp",
     "cfpEndDate": "2026-06-01",
     "twitter": "@AIDevConf"
+  },
+  {
+    "name": "SciPy India",
+    "url": "https://scipy.in/2026/",
+    "startDate": "2026-12-19",
+    "endDate": "2026-12-20",
+    "city": "Chennai",
+    "country": "India",
+    "online": false,
+    "locales": "EN",
+    "cocUrl": "https://scipy.in/2026/coc.html",
+    "bluesky": "scipy.in",
+    "twitter": "@scipy_india"
   }
 ]

--- a/conferences/2026/opensource.json
+++ b/conferences/2026/opensource.json
@@ -419,5 +419,18 @@
     "cocUrl": "https://fossforall.org/en/disclosures/legal/code-of-conduct/",
     "mastodon": "@fossforall@mastodon.social",
     "twitter": "@FOSS_for_All"
+  },
+  {
+    "name": "SciPy India",
+    "url": "https://scipy.in/2026/",
+    "startDate": "2026-12-19",
+    "endDate": "2026-12-20",
+    "city": "Chennai",
+    "country": "India",
+    "online": false,
+    "locales": "EN",
+    "cocUrl": "https://scipy.in/2026/coc.html",
+    "bluesky": "scipy.in",
+    "twitter": "@scipy_india"
   }
 ]

--- a/conferences/2026/python.json
+++ b/conferences/2026/python.json
@@ -102,5 +102,18 @@
     "cfpUrl": "http://www.zindell.com/documents/codeofconduct.pdf",
     "cfpEndDate": "2026-07-10",
     "twitter": "@xtremepython"
+  },
+  {
+    "name": "SciPy India",
+    "url": "https://scipy.in/2026/",
+    "startDate": "2026-12-19",
+    "endDate": "2026-12-20",
+    "city": "Chennai",
+    "country": "India",
+    "online": false,
+    "locales": "EN",
+    "cocUrl": "https://scipy.in/2026/coc.html",
+    "bluesky": "scipy.in",
+    "twitter": "@scipy_india"
   }
 ]


### PR DESCRIPTION
Thanks for creating a new Pull Request for this repository.

To get the conference as fast as possible into confs.tech please consider the following things.

## Checklist for your change
- [x] does not delete another conference
- [x] has passed the tests via `npm run test`
- [x] has the correct order via `npm run reorder-confs`
- [x] is a developer conference: more than 3-4 people from different companies
- [x] is not a webinar, hackathon, marketing, zoom meeting with one person
- [x] URLs are reachable, as short as possible, do not contain tracking parameters and the website is dedicated for this event
- [x] topic is correct
- [x] conference name is as short as possible and does not include location and date

Hi! I'm an organiser for the @scipy-india conference, and would like to submit this data. Thank you!