### PR TITLE
Remove cancelled OpenTechDay: Software-defined Storage (Oct 1, 2026)

### DIFF
--- a/conferences/2026/opensource.json
+++ b/conferences/2026/opensource.json
@@ -281,20 +281,6 @@
     "twitter": "@btcplusplus"
   },
   {
-    "name": "Open Tech Day: Software-defined Storage",
-    "url": "https://opentechday.de",
-    "startDate": "2026-10-01",
-    "endDate": "2026-10-01",
-    "city": "Nürnberg",
-    "country": "Germany",
-    "online": false,
-    "locales": "EN,DE",
-    "offersSignLanguageOrCC": true,
-    "cocUrl": "https://opentechday.de/code-of-conduct/",
-    "cfpUrl": "https://opentechday.de/propose",
-    "cfpEndDate": "2026-05-31"
-  },
-  {
     "name": "bitcoin++ payments edition",
     "url": "https://btcpp.dev/berlin26",
     "startDate": "2026-10-01",


### PR DESCRIPTION
Thanks for creating a new Pull Request for this repository.

To get the conference as fast as possible into confs.tech please consider the following things.

## Checklist for your change
- [ ] does not delete another conference
- [ ] has passed the tests via `npm run test`
- [ ] has the correct order via `npm run reorder-confs`
- [ ] is a developer conference: more than 3-4 people from different companies
- [ ] is not a webinar, hackathon, marketing, zoom meeting with one person
- [ ] URLs are reachable, as short as possible, do not contain tracking parameters and the website is dedicated for this event
- [ ] topic is correct
- [ ] conference name is as short as possible and does not include location and date
