### PR TITLE
Update API Conference Berlin and MLCon Berlin 2026 dates

### DIFF
--- a/conferences/2026/api.json
+++ b/conferences/2026/api.json
@@ -140,8 +140,8 @@
   {
     "name": "API Conference Berlin",
     "url": "https://apiconference.net/berlin",
-    "startDate": "2026-11-23",
-    "endDate": "2026-11-27",
+    "startDate": "2026-11-16",
+    "endDate": "2026-11-20",
     "city": "Berlin",
     "country": "Germany",
     "online": true,

--- a/conferences/2026/data.json
+++ b/conferences/2026/data.json
@@ -974,8 +974,8 @@
   {
     "name": "MLCon Berlin",
     "url": "https://mlconference.ai/berlin",
-    "startDate": "2026-11-23",
-    "endDate": "2026-11-27",
+    "startDate": "2026-11-16",
+    "endDate": "2026-11-20",
     "city": "Berlin",
     "country": "Germany",
     "online": true,

--- a/conferences/2026/data.json
+++ b/conferences/2026/data.json
@@ -948,6 +948,17 @@
     "locales": "DE"
   },
   {
+    "name": "MLCon Berlin",
+    "url": "https://mlconference.ai/berlin",
+    "startDate": "2026-11-16",
+    "endDate": "2026-11-20",
+    "city": "Berlin",
+    "country": "Germany",
+    "online": true,
+    "locales": "EN",
+    "twitter": "@mlconference"
+  },
+  {
     "name": "VibeKode Berlin",
     "url": "https://vibekode.it/berlin",
     "startDate": "2026-11-16",
@@ -970,17 +981,6 @@
     "cocUrl": "https://www.agenticdays.com/code-of-conduct.html",
     "cfpUrl": "https://sessionize.com/agentic-engineering-days-zurich-2026",
     "cfpEndDate": "2026-07-23"
-  },
-  {
-    "name": "MLCon Berlin",
-    "url": "https://mlconference.ai/berlin",
-    "startDate": "2026-11-16",
-    "endDate": "2026-11-20",
-    "city": "Berlin",
-    "country": "Germany",
-    "online": true,
-    "locales": "EN",
-    "twitter": "@mlconference"
   },
   {
     "name": "XtremeAI Online Conference",

--- a/conferences/2026/devops.json
+++ b/conferences/2026/devops.json
@@ -410,6 +410,17 @@
     "cfpEndDate": "2026-04-21"
   },
   {
+    "name": "API Conference Berlin",
+    "url": "https://apiconference.net/berlin",
+    "startDate": "2026-11-16",
+    "endDate": "2026-11-20",
+    "city": "Berlin",
+    "country": "Germany",
+    "online": true,
+    "locales": "EN",
+    "twitter": "@api_conference"
+  },
+  {
     "name": "X-Ops Conference Madrid",
     "url": "https://xopsconference.com",
     "startDate": "2026-11-19",
@@ -421,17 +432,6 @@
     "cfpUrl": "https://sessionize.com/x-ops-conference-2026",
     "cfpEndDate": "2026-08-31",
     "twitter": "@xopsconference"
-  },
-  {
-    "name": "API Conference Berlin",
-    "url": "https://apiconference.net/berlin",
-    "startDate": "2026-11-16",
-    "endDate": "2026-11-20",
-    "city": "Berlin",
-    "country": "Germany",
-    "online": true,
-    "locales": "EN",
-    "twitter": "@api_conference"
   },
   {
     "name": "DevOpsCon Munich",

--- a/conferences/2026/devops.json
+++ b/conferences/2026/devops.json
@@ -425,8 +425,8 @@
   {
     "name": "API Conference Berlin",
     "url": "https://apiconference.net/berlin",
-    "startDate": "2026-11-23",
-    "endDate": "2026-11-27",
+    "startDate": "2026-11-16",
+    "endDate": "2026-11-20",
     "city": "Berlin",
     "country": "Germany",
     "online": true,

--- a/conferences/2026/security.json
+++ b/conferences/2026/security.json
@@ -336,6 +336,17 @@
     "locales": "EN"
   },
   {
+    "name": "API Conference Berlin",
+    "url": "https://apiconference.net/berlin",
+    "startDate": "2026-11-16",
+    "endDate": "2026-11-20",
+    "city": "Berlin",
+    "country": "Germany",
+    "online": true,
+    "locales": "EN",
+    "twitter": "@api_conference"
+  },
+  {
     "name": "X-Ops Conference Madrid",
     "url": "https://xopsconference.com",
     "startDate": "2026-11-19",
@@ -347,17 +358,6 @@
     "cfpUrl": "https://sessionize.com/x-ops-conference-2026",
     "cfpEndDate": "2026-08-31",
     "twitter": "@xopsconference"
-  },
-  {
-    "name": "API Conference Berlin",
-    "url": "https://apiconference.net/berlin",
-    "startDate": "2026-11-16",
-    "endDate": "2026-11-20",
-    "city": "Berlin",
-    "country": "Germany",
-    "online": true,
-    "locales": "EN",
-    "twitter": "@api_conference"
   },
   {
     "name": "Workplace Ninjas India",

--- a/conferences/2026/security.json
+++ b/conferences/2026/security.json
@@ -351,8 +351,8 @@
   {
     "name": "API Conference Berlin",
     "url": "https://apiconference.net/berlin",
-    "startDate": "2026-11-23",
-    "endDate": "2026-11-27",
+    "startDate": "2026-11-16",
+    "endDate": "2026-11-20",
     "city": "Berlin",
     "country": "Germany",
     "online": true,


### PR DESCRIPTION
## Summary
- Update **API Conference Berlin 2026** dates from November 23–27 to November 16–20 (api, devops, security)
- Update **MLCon Berlin 2026** dates from November 23–27 to November 16–20 (data)
- **BASTA! Fall 2026** (listed as BASTA! Herbst) already had the correct dates (September 28–October 2) — no change needed

Requested by Software & Support Media GmbH.

## Test plan
- [ ] Verify API Conference Berlin shows November 16–20, 2026
- [ ] Verify MLCon Berlin shows November 16–20, 2026
- [ ] Confirm BASTA! Herbst 2026 remains September 28–October 2, 2026


Made with [Cursor](https://cursor.com)