### PR TITLE
Add Enterprise AI Summit (Charlotte, NC)

### DIFF
--- a/conferences/2026/data.json
+++ b/conferences/2026/data.json
@@ -762,6 +762,16 @@
     "cocUrl": "https://agenticai.bettercode.eu/code_of_conduct.php"
   },
   {
+    "name": "Enterprise AI Summit",
+    "url": "https://events.itrevolution.com/2026-charlotte/",
+    "startDate": "2026-10-07",
+    "endDate": "2026-10-08",
+    "city": "Charlotte, NC",
+    "country": "U.S.A.",
+    "online": false,
+    "locales": "EN"
+  },
+  {
     "name": "World Summit AI",
     "url": "https://worldsummit.ai",
     "startDate": "2026-10-07",

--- a/conferences/2026/leadership.json
+++ b/conferences/2026/leadership.json
@@ -72,6 +72,16 @@
     "twitter": "@aipivotconf"
   },
   {
+    "name": "Enterprise AI Summit",
+    "url": "https://events.itrevolution.com/2026-charlotte/",
+    "startDate": "2026-10-07",
+    "endDate": "2026-10-08",
+    "city": "Charlotte, NC",
+    "country": "U.S.A.",
+    "online": false,
+    "locales": "EN"
+  },
+  {
     "name": "Fast Flow Conf",
     "url": "https://www.fastflowconf.com",
     "startDate": "2026-10-13",


### PR DESCRIPTION
Adds the **Enterprise AI Summit** (Charlotte, NC — October 7–8, 2026) to `data` and `leadership` for 2026.

A two-day, talks-only conference from IT Revolution (the team behind the DevOps Enterprise Summit) on shipping AI in production in large enterprises.

## Checklist for your change
- [x] does not delete another conference
- [x] has passed the tests via `npm run test` — *"Checks for all 6011 conferences have passed successfully"*
- [x] has the correct order via `npm run reorder-confs` — produces no further changes
- [x] is a developer conference: more than 3-4 people from different companies — 15 announced speakers from 15 different organisations, including Northrop Grumman, adidas, Red Hat, Mastercard, Hilton, M&T Bank, Planview and Coder
- [x] is not a webinar, hackathon, marketing, zoom meeting with one person
- [x] URLs are reachable, as short as possible, do not contain tracking parameters and the website is dedicated for this event
- [x] topic is correct — `data` for the AI subject matter, `leadership` for the technology-leader audience (following the precedent of AI Pivot Conference, Fast Flow Conf and TechEx Europe, which are listed under both)
- [x] conference name is as short as possible and does not include location and date

There is no CFP, code of conduct or event-specific social account published for this edition, so those optional fields are omitted rather than filled in with placeholders. Happy to drop the `leadership` entry if you would rather keep it to a single topic.